### PR TITLE
HARMONY-684: Setup GitHub actions for publication to PyPI with release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,15 @@
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,15 @@
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Release Drafter
+      uses: release-drafter/release-drafter@v5.12.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,8 +1,9 @@
 name: Publish Release
 
-on:
-  release:
-    types: [published]
+on: [workflow_dispatch]
+  # Harmony 683: Uncomment these lines line to publish in CI upon release after setting up secrets
+  # release:
+  #   types: [published]
 
 jobs:
   build:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,24 @@
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    # github.sha, github.ref : https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
+    #
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - shell: bash
+      env:
+        REPO_PASS: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        VERSION=$(echo ${{github.event.release.tag_name}} | cut -c2-) make build
+        make publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Tests
 
-on:
-  pull_request: {}
-  push:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Build & publish the package:
 
 ## Releasing
 
-Update the CHANGELOG with a short bulleted description of the changes
-to be built & deployed. Replace `DATE` with the date on which the
-feature will be released.
+GitHub release notes will automatically be generated based on pull request subjects.
+Pull request subject lines should therefore concisely emphasize library
+user-facing behavior and updates they should appear in the changelog.  If more
+information is needed for release notes, note that in the PR content.

--- a/makefile
+++ b/makefile
@@ -1,12 +1,14 @@
 .PHONY: clean build publish test develop
 
 VERSION ?= $(shell git describe --tags | sed 's/-/\+/' | sed 's/-/\./g')
-REPO ?= https://pypi.python.org/pypi
-REPO_USER ?= unset
+REPO ?= https://upload.pypi.org/legacy/
+REPO_USER ?= __token__
 REPO_PASS ?= unset
 
-build: clean
+version:
 	sed -i.bak "s/__version__ .*/__version__ = \"$(VERSION)\"/" harmony/__init__.py && rm harmony/__init__.py.bak
+
+build: clean version
 	python -m pip install --upgrade --quiet setuptools wheel twine
 	python setup.py --quiet sdist bdist_wheel
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def get_version():
 setup(
     name="harmony-service-lib",
     version=get_version(),
-    author="Patrick Quinn",
+    author="NASA EOSDIS Harmony Team",
     author_email="patrick@element84.com",
     description=("A library for Python-based Harmony services to parse incoming messages, "
                  "fetch data, stage data, and call back to Harmony"),
@@ -61,14 +61,13 @@ setup(
         'dev': DEV_DEPENDENCIES
     },
     test_suite="tests",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     # license and classifier list:
     # https://pypi.org/pypi?%3Aaction=list_classifiers
-    license="License :: none License",
+    license="License :: OSI Approved :: Apache Software License",
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Operating System :: OS Independent",
-        "Private :: Do Not Upload"
+        "Operating System :: OS Independent"
     ],
 )


### PR DESCRIPTION
A couple of notes:
1. After this change, by default, a release will be drafted / edited on merge.  It will summarize our changes using PR subjects, so we need to word them for use as release notes
2. Releases will automatically bump major/minor/patch versions.  By default, the patch version will be bumped.  If a PR needs a major or minor version bump, add the label "major" or "minor" to it accordingly.
3. Publication of releases to PyPI needs to be manual until I can set up tokens in our GitHub account.  I'm going to save this for later, so I can set up several other admin things all at once.  I'll comment out the actual publication for now and PR to restore it after it is set up.