### PR TITLE
HARMONY-831 - Ensure a URL with query parameters is downloaded with the correct file extension

### DIFF
--- a/harmony/util.py
+++ b/harmony/util.py
@@ -230,7 +230,7 @@ def _filename(directory_path: str, url: str) -> Path:
     return Path(
         directory_path,
         hashlib.sha256(url.encode('utf-8')).hexdigest()
-    ).with_suffix(PurePath(url).suffix)
+    ).with_suffix(PurePath(parse.urlparse(url).path).suffix)
 
 
 def download(url, destination_dir, logger=None, access_token=None, data=None, cfg=None):

--- a/tests/test_util_download.py
+++ b/tests/test_util_download.py
@@ -80,6 +80,23 @@ def test_when_given_a_file_path_it_returns_the_file_path(monkeypatch, mocker, fa
         assert destination_path.endswith('.txt')
 
 
+def test_when_given_file_url_with_parameters_returns_file_path(monkeypatch,
+                                                               mocker, faker):
+    access_token = faker.password(length=40, special_chars=False)
+    http_download = mocker.Mock()
+    monkeypatch.setattr(util.http, 'download', http_download)
+    config = config_fixture()
+
+    with mock.patch('builtins.open', mock.mock_open()):
+        destination_path = util.download(
+            'https://example.com/file.nc4?dap4.ce=latitude',
+            '/put/file/here/', access_token=access_token, cfg=config
+        )
+
+        assert destination_path.startswith('/put/file/here/')
+        assert destination_path.endswith('.nc4')
+
+
 @responses.activate
 def test_when_the_url_returns_a_401_it_throws_a_forbidden_exception(faker):
     access_token = faker.password(length=40, special_chars=False)


### PR DESCRIPTION
This PR updates the `harmony.util._filename` function, so that if a user requests a URL with query parameters, those parameters aren't included in the file extension the downloaded output is saved to. For example:

```
https://opendap.earthdata.nasa.gov/this/is/my/file.dap.nc4?dap4.ce=variableOne
```
Right now, this gives the extension `.ce=variableOne`, instead of `.nc4`.

I did a quick check of how `urlparse` works with different URL types, and file paths, and found the following:

* `PurePath(parse.urlparse('https://opendap.earthdata.nasa.gov/this/is/my/file.dap.nc4?dap4.ce=variableOne').path).suffix` --> `'.nc4'`
* `PurePath(parse.urlparse('https://opendap.earthdata.nasa.gov/this/is/my/file.dap.nc4').path).suffix` --> `'.nc4'`
* `PurePath(parse.urlparse('https://www.google.com').path).suffix` --> `''`
* `PurePath(parse.urlparse('file:///path/to/local/file.ext').path).suffix` --> `'.ext'`
* `PurePath(parse.urlparse('/path/to/local/file.ext').path).suffix` --> `'.ext'`