### PR TITLE
DAS-1076: Remove URL encoding of POST query parameters.

### DIFF
--- a/harmony/http.py
+++ b/harmony/http.py
@@ -12,7 +12,7 @@ set for correct operation. See that module and the project README for details.
 
 from functools import lru_cache
 import json
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlparse
 import datetime
 import sys
 import re
@@ -286,10 +286,6 @@ def download(config, url: str, access_token: str, data, destination_file):
     logger = build_logger(config)
     start_time = datetime.datetime.now()
     logger.info(f'timing.download.start {url}')
-
-    if data is not None:
-        logger.info('Query parameters supplied, will use POST method.')
-        data = urlencode(data).encode('utf-8')
 
     if access_token is not None and _valid(config.oauth_host, config.oauth_client_id, access_token):
         response = _download(config, url, access_token, data)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -250,7 +250,7 @@ def test_download_validates_token_and_raises_exception(
 
 
 @responses.activate
-def test_when_given_a_url_and_data_it_downloads_with_query_string(
+def test_when_given_a_url_and_data_it_downloads_with_query_parameters(
         monkeypatch,
         mocker,
         access_token,
@@ -270,7 +270,7 @@ def test_when_given_a_url_and_data_it_downloads_with_query_string(
 
     assert response.status_code == 200
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.body == b'param=value'
+    assert responses.calls[0].request.body == 'param=value'
 
 
 @responses.activate


### PR DESCRIPTION
This PR removes the URL encoding of the `data` dictionary that is given to `requests.post`. The `data` keyword argument is [expecting](https://docs.python-requests.org/en/master/user/quickstart/#more-complicated-post-requests) a regular dictionary or a string dump using `json.dumps`, rather than a URL encoded string.

The original intent behind the URL encoding was because OPeNDAP requires any constraint expression to be URL encoded (as variable paths can have slashes in them). This is better handled by encoding just the value of the constraint expression, rather than the whole data dictionary.