### PR TITLE
HARMONY-833: Publish to PyPI when a release is published

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,10 +34,5 @@ jobs:
         git commit -m "Update release version to ${VERSION_TAG}"
         git push origin "${BRANCH}"
 
-        # Move the tag without using --force
-        # Delete the old tag and push the change
-        git tag -d "${VERSION_TAG}"
-        git push origin :"${VERSION_TAG}"
-        # Create the new tag and push the change
-        git tag "${VERSION_TAG}"
-        git push origin "${VERSION_TAG}"
+        git tag --force "${VERSION_TAG}"
+        git push --force origin "${VERSION_TAG}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,13 +24,21 @@ jobs:
         echo "make publish to ${BRANCH}"
         # make publish
 
+        # Setup git
         # https://api.github.com/users/github-actions%5Bbot%5D
         git config --global user.name "github-actions[bot]"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+        # Commit and push updated release files
         git checkout -b "${BRANCH}"
         git add .
         git commit -m "Update release version to ${VERSION_TAG}"
-        git tag -f "${VERSION_TAG}"
         git push origin "${BRANCH}"
+
+        # Move the tag without using --force
+        # Delete the old tag and push the change
+        git tag -d "${VERSION_TAG}"
+        git push origin :"${VERSION_TAG}"
+        # Create the new tag and push the change
+        git tag "${VERSION_TAG}"
         git push origin "${VERSION_TAG}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,6 +16,11 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'
+    - uses: pocket-apps/action-update-version@v1
+      with:
+        files: 'harmony/__init__.py'
+        version-regexp: '\d+.\d+.\d+'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - shell: bash
       env:
         REPO_PASS: ${{ secrets.PYPI }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
         BRANCH: ${{ github.event.release.target_commitish }}
       run: |
         VERSION=$(echo "${VERSION_TAG}" | cut -c2-) make build
-        make publish
+        # make publish
 
         # Setup git
         # https://api.github.com/users/github-actions%5Bbot%5D

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
         BRANCH: ${{ github.event.release.target_commitish }}
       run: |
         VERSION=$(echo "${VERSION_TAG}" | cut -c2-) make build
-        # make publish
+        make publish
 
         # Setup git
         # https://api.github.com/users/github-actions%5Bbot%5D

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,22 +8,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    # github.sha, github.ref : https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
-    #
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-    - uses: pocket-apps/action-update-version@v1
-      with:
-        files: 'harmony/__init__.py'
-        version-regexp: '\d+.\d+.\d+'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - shell: bash
       env:
         REPO_PASS: ${{ secrets.PYPI }}
+        VERSION_TAG: ${{github.event.release.tag_name}}
       run: |
-        VERSION=$(echo ${{github.event.release.tag_name}} | cut -c2-) make build
-        make publish
+        VERSION=$(echo "${VERSION_TAG}" | cut -c2-) make build
+        echo "make publish"
+        # make publish
+
+        git config --global user.name $(git show -s --format='%an')
+        git config --global user.email $(git show -s --format='%ae')
+        git commit -a -m "Update release version (Automated commit)"
+        git add .
+        git commit -m "Version bump to ${VERSION_TAG}"
+        git tag -f "${VERSION_TAG}"
+        git push
+        git push origin "${VERSION_TAG}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,17 +17,20 @@ jobs:
     - shell: bash
       env:
         REPO_PASS: ${{ secrets.PYPI }}
-        VERSION_TAG: ${{github.event.release.tag_name}}
+        VERSION_TAG: ${{ github.event.release.tag_name }}
+        BRANCH: ${{ github.event.release.target_commitish }}
       run: |
         VERSION=$(echo "${VERSION_TAG}" | cut -c2-) make build
-        echo "make publish"
+        echo "make publish to ${BRANCH}"
         # make publish
 
-        git config --global user.name $(git show -s --format='%an')
-        git config --global user.email $(git show -s --format='%ae')
-        git commit -a -m "Update release version (Automated commit)"
+        # https://api.github.com/users/github-actions%5Bbot%5D
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        git checkout -b "${BRANCH}"
         git add .
-        git commit -m "Version bump to ${VERSION_TAG}"
+        git commit -m "Update release version to ${VERSION_TAG}"
         git tag -f "${VERSION_TAG}"
-        git push
+        git push origin "${BRANCH}"
         git push origin "${VERSION_TAG}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,8 +21,7 @@ jobs:
         BRANCH: ${{ github.event.release.target_commitish }}
       run: |
         VERSION=$(echo "${VERSION_TAG}" | cut -c2-) make build
-        echo "make publish to ${BRANCH}"
-        # make publish
+        make publish
 
         # Setup git
         # https://api.github.com/users/github-actions%5Bbot%5D

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,9 +1,8 @@
 name: Publish Release
 
-on: [workflow_dispatch]
-  # Harmony 683: Uncomment these lines line to publish in CI upon release after setting up secrets
-  # release:
-  #   types: [published]
+on:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -19,7 +18,7 @@ jobs:
         python-version: '3.8'
     - shell: bash
       env:
-        REPO_PASS: ${{ secrets.PYPI_TOKEN }}
+        REPO_PASS: ${{ secrets.PYPI }}
       run: |
         VERSION=$(echo ${{github.event.release.tag_name}} | cut -c2-) make build
         make publish

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -7,7 +7,7 @@ Convenience exports for the Harmony library
 """
 
 # Automatically updated by `make build`
-__version__ = "1.0.8-alpha.4"
+__version__ = "1.0.8-alpha.5"
 
 from .adapter import BaseHarmonyAdapter
 from .cli import setup_cli, is_harmony_cli, run_cli

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -7,7 +7,7 @@ Convenience exports for the Harmony library
 """
 
 # Automatically updated by `make build`
-__version__ = "1.0.8-alpha.5"
+__version__ = "1.0.8-alpha.6"
 
 from .adapter import BaseHarmonyAdapter
 from .cli import setup_cli, is_harmony_cli, run_cli

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -7,7 +7,7 @@ Convenience exports for the Harmony library
 """
 
 # Automatically updated by `make build`
-__version__ = "1.0.8-alpha.6"
+__version__ = "1.0.8"
 
 from .adapter import BaseHarmonyAdapter
 from .cli import setup_cli, is_harmony_cli, run_cli

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -7,7 +7,7 @@ Convenience exports for the Harmony library
 """
 
 # Automatically updated by `make build`
-__version__ = "0.0.1"
+__version__ = "1.0.8-alpha.3"
 
 from .adapter import BaseHarmonyAdapter
 from .cli import setup_cli, is_harmony_cli, run_cli

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -7,7 +7,7 @@ Convenience exports for the Harmony library
 """
 
 # Automatically updated by `make build`
-__version__ = "1.0.8-alpha.3"
+__version__ = "1.0.8-alpha.4"
 
 from .adapter import BaseHarmonyAdapter
 from .cli import setup_cli, is_harmony_cli, run_cli


### PR DESCRIPTION
Successfully published v1.0.8 pointing to this branch:
https://github.com/nasa/harmony-service-lib-py/runs/2503228502?check_suite_focus=true
https://pypi.org/project/harmony-service-lib/1.0.8/