### PR TITLE
Harmony 838

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 autopep8 ~= 1.5
 debugpy ~= 1.2
-Faker ~= 6.0
+Faker ~= 8.1.3
 flake8 ~= 3.8
 ipython ~= 7.17
 jedi ~= 0.17.2

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 import json
 from urllib.parse import urlparse
 import datetime
+import sys
 import os
 import re
 
@@ -326,11 +327,15 @@ def download(config, url: str, access_token: str, data, destination_file,
             response = _download_with_fallback_authn(config, url, data, user_agent, stream=stream)
 
     if response.ok:
-        for chunk in response.iter_content(chunk_size=chunk_size):
-            destination_file.write(chunk)
+        if not stream:
+            destination_file.write(response.content)
+            file_size = sys.getsizeof(response.content)
+        else:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                destination_file.write(chunk)
+            file_size = os.path.getsize(destination_file.name)
         time_diff = datetime.datetime.now() - start_time
         duration_ms = int(round(time_diff.total_seconds() * 1000))
-        file_size = os.path.getsize(destination_file.name)
         duration_logger = build_logger(config)
         _log_download_performance(duration_logger, url, duration_ms, file_size)
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -134,7 +134,7 @@ def _earthdata_session():
     return EarthdataSession()
 
 
-def _download(config, url: str, access_token: str, data, user_agent=None, **kwargs):
+def _download(config, url: str, access_token: str, data, user_agent=None, **kwargs_download_agent):
     """Implements the download functionality.
 
     Using the EarthdataSession and EarthdataAuth extensions to the
@@ -172,15 +172,15 @@ def _download(config, url: str, access_token: str, data, user_agent=None, **kwar
     with _earthdata_session() as session:
         session.auth = auth
         if data is None:
-            return session.get(url, headers=headers, timeout=TIMEOUT, **kwargs)
+            return session.get(url, headers=headers, timeout=TIMEOUT, **kwargs_download_agent)
         else:
             # Including this header since the stdlib does by default,
             # but we've switched to `requests` which does not.
             headers['Content-Type'] = 'application/x-www-form-urlencoded'
-            return session.post(url, headers=headers, data=data, timeout=TIMEOUT, **kwargs)
+            return session.post(url, headers=headers, data=data, timeout=TIMEOUT, **kwargs_download_agent)
 
 
-def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwargs):
+def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwargs_download_agent):
     """Downloads the given url using Basic authentication as a fallback
     mechanism should the normal EDL Oauth handshake fail.
 
@@ -214,9 +214,9 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwa
         headers['user-agent'] = user_agent
     auth = requests.auth.HTTPBasicAuth(config.edl_username, config.edl_password)
     if data is None:
-        return requests.get(url, headers=headers, timeout=TIMEOUT, auth=auth, **kwargs)
+        return requests.get(url, headers=headers, timeout=TIMEOUT, auth=auth, **kwargs_download_agent)
     else:
-        return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth, **kwargs)
+        return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth, **kwargs_download_agent)
 
 
 def _log_download_performance(logger, url, duration_ms, file_size):

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -172,7 +172,7 @@ def _download(config, url: str, access_token: str, data, user_agent=None):
     with _earthdata_session() as session:
         session.auth = auth
         if data is None:
-            return session.get(url, headers=headers, timeout=TIMEOUT)
+            return session.get(url, stream=True, headers=headers, timeout=TIMEOUT)
         else:
             # Including this header since the stdlib does by default,
             # but we've switched to `requests` which does not.

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -272,10 +272,8 @@ def _preprocess_download_kwargs(download_kwargs: dict, logger):
           and the chunksize is set to be 16MB based on the experiment with a large file of 1.8Gb
           for optimized speed and memory consumption.
     """
-    download_kwargs.setdefault('stream', True)
-    download_kwargs.setdefault('chunk_size', 1024*1024*16)
-    stream = download_kwargs['stream'] if 'stream' in download_kwargs else False
-    chunk_size = download_kwargs['chunk_size'] if 'chunk_size' in download_kwargs else None
+    stream = download_kwargs.setdefault('stream', True)
+    chunk_size = download_kwargs.setdefault('chunk_size', 1024*1024*16)
     if (not stream) and chunk_size:
         logger.warn(
             f"In download paramters, chunk_size={chunk_size} will be ignored since stream is set to be {stream}."

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -15,6 +15,7 @@ import json
 from urllib.parse import urlparse
 import datetime
 import sys
+import os
 import re
 
 import requests
@@ -323,7 +324,7 @@ def download(config, url: str, access_token: str, data, destination_file, user_a
             destination_file.write(chunk)
         time_diff = datetime.datetime.now() - start_time
         duration_ms = int(round(time_diff.total_seconds() * 1000))
-        file_size = sys.getsizeof(response.content)
+        file_size = os.path.getsize(destination_file.name)
         duration_logger = build_logger(config)
         _log_download_performance(duration_logger, url, duration_ms, file_size)
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -306,6 +306,8 @@ def download(config, url: str, access_token: str, data, destination_file,
     NOTE: streaming request is used to download the file,
           and the chunksize is defaulted to 16MB based on the experiment with a large file of 1.8Gb
           for optimized speed and memory consumption.
+          If you are experiencing some performance decay for high-throughput small-sized granules,
+          you may want to set stream=False.
     """
 
     response = None

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -309,14 +309,14 @@ def download(config, url: str, access_token: str, data, destination_file, user_a
     logger.info(f'timing.download.start {url}')
 
     if access_token is not None and _valid(config.oauth_host, config.oauth_client_id, access_token):
-        response = _download(config, url, access_token, data, user_agent)
+        response = _download(config, url, access_token, data, user_agent, stream=True)
 
     if response is None or not response.ok:
         if config.fallback_authn_enabled:
             msg = ('No valid user access token in request or EDL OAuth authentication failed.'
                    'Fallback authentication enabled: retrying with Basic auth.')
             logger.warning(msg)
-            response = _download_with_fallback_authn(config, url, data, user_agent)
+            response = _download_with_fallback_authn(config, url, data, user_agent, stream=True)
 
     if response.ok:
         time_diff = datetime.datetime.now() - start_time

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -159,6 +159,9 @@ def _download(config, url: str, access_token: str, data, user_agent=None, **kwar
     user_agent : str
         The user agent that is requesting the download.
         E.g. harmony/0.0.0 (harmony-sit) harmony-service-lib/4.0 (gdal-subsetter)
+    kwargs_download_agent: dict
+        kwargs to be passed to the download agent
+        E.g. stream=True
 
     Returns
     -------
@@ -203,6 +206,9 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwa
     user_agent : str
         The user agent that is requesting the download.
         E.g. harmony/0.0.0 (harmony-sit) harmony-service-lib/4.0 (gdal-subsetter)
+    kwargs_download_agent: dict
+        kwargs to be passed to the download agent
+        E.g. stream=True
 
     Returns
     -------

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -302,6 +302,9 @@ def download(config, url: str, access_token: str, data, destination_file, user_a
     Side-effects
     ------------
     Will write to provided destination_file
+    NOTE: streaming request is used to download the file,
+    and the chunksize of 16MB is chosen based on the experiment with a large file of 1.8Gb
+    for optimized speed and memory consumption.
     """
 
     response = None

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -134,7 +134,7 @@ def _earthdata_session():
     return EarthdataSession()
 
 
-def _download(config, url: str, access_token: str, data, user_agent=None):
+def _download(config, url: str, access_token: str, data, user_agent=None, stream=True):
     """Implements the download functionality.
 
     Using the EarthdataSession and EarthdataAuth extensions to the
@@ -159,6 +159,8 @@ def _download(config, url: str, access_token: str, data, user_agent=None):
     user_agent : str
         The user agent that is requesting the download.
         E.g. harmony/0.0.0 (harmony-sit) harmony-service-lib/4.0 (gdal-subsetter)
+    stream : boolean
+        Flag which will be passed to requests module when making download request
 
     Returns
     -------
@@ -172,7 +174,7 @@ def _download(config, url: str, access_token: str, data, user_agent=None):
     with _earthdata_session() as session:
         session.auth = auth
         if data is None:
-            return session.get(url, stream=True, headers=headers, timeout=TIMEOUT)
+            return session.get(url, stream=stream, headers=headers, timeout=TIMEOUT)
         else:
             # Including this header since the stdlib does by default,
             # but we've switched to `requests` which does not.
@@ -180,7 +182,7 @@ def _download(config, url: str, access_token: str, data, user_agent=None):
             return session.post(url, headers=headers, data=data, timeout=TIMEOUT)
 
 
-def _download_with_fallback_authn(config, url: str, data, user_agent=None):
+def _download_with_fallback_authn(config, url: str, data, user_agent=None, stream=True):
     """Downloads the given url using Basic authentication as a fallback
     mechanism should the normal EDL Oauth handshake fail.
 
@@ -203,6 +205,8 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None):
     user_agent : str
         The user agent that is requesting the download.
         E.g. harmony/0.0.0 (harmony-sit) harmony-service-lib/4.0 (gdal-subsetter)
+    stream : boolean
+        Flag which will be passed to requests module when making download request
 
     Returns
     -------
@@ -214,7 +218,7 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None):
         headers['user-agent'] = user_agent
     auth = requests.auth.HTTPBasicAuth(config.edl_username, config.edl_password)
     if data is None:
-        return requests.get(url, stream=True, headers=headers, timeout=TIMEOUT, auth=auth)
+        return requests.get(url, stream=stream, headers=headers, timeout=TIMEOUT, auth=auth)
     else:
         return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth)
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -319,9 +319,10 @@ def download(config, url: str, access_token: str, data, destination_file, user_a
             response = _download_with_fallback_authn(config, url, data, user_agent, stream=True)
 
     if response.ok:
+        for chunk in response.iter_content(chunk_size=1024*1024*16):
+            destination_file.write(chunk)
         time_diff = datetime.datetime.now() - start_time
         duration_ms = int(round(time_diff.total_seconds() * 1000))
-        destination_file.write(response.content)
         file_size = sys.getsizeof(response.content)
         duration_logger = build_logger(config)
         _log_download_performance(duration_logger, url, duration_ms, file_size)

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -303,8 +303,8 @@ def download(config, url: str, access_token: str, data, destination_file, user_a
     ------------
     Will write to provided destination_file
     NOTE: streaming request is used to download the file,
-    and the chunksize of 16MB is chosen based on the experiment with a large file of 1.8Gb
-    for optimized speed and memory consumption.
+          and the chunksize of 16MB is chosen based on the experiment with a large file of 1.8Gb
+          for optimized speed and memory consumption.
     """
 
     response = None

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -134,7 +134,7 @@ def _earthdata_session():
     return EarthdataSession()
 
 
-def _download(config, url: str, access_token: str, data, user_agent=None, stream=True):
+def _download(config, url: str, access_token: str, data, user_agent=None, **kwargs):
     """Implements the download functionality.
 
     Using the EarthdataSession and EarthdataAuth extensions to the
@@ -159,8 +159,6 @@ def _download(config, url: str, access_token: str, data, user_agent=None, stream
     user_agent : str
         The user agent that is requesting the download.
         E.g. harmony/0.0.0 (harmony-sit) harmony-service-lib/4.0 (gdal-subsetter)
-    stream : boolean
-        Flag which will be passed to requests module when making download request
 
     Returns
     -------
@@ -174,15 +172,15 @@ def _download(config, url: str, access_token: str, data, user_agent=None, stream
     with _earthdata_session() as session:
         session.auth = auth
         if data is None:
-            return session.get(url, stream=stream, headers=headers, timeout=TIMEOUT)
+            return session.get(url, headers=headers, timeout=TIMEOUT, **kwargs)
         else:
             # Including this header since the stdlib does by default,
             # but we've switched to `requests` which does not.
             headers['Content-Type'] = 'application/x-www-form-urlencoded'
-            return session.post(url, headers=headers, data=data, timeout=TIMEOUT)
+            return session.post(url, headers=headers, data=data, timeout=TIMEOUT, **kwargs)
 
 
-def _download_with_fallback_authn(config, url: str, data, user_agent=None, stream=True):
+def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwargs):
     """Downloads the given url using Basic authentication as a fallback
     mechanism should the normal EDL Oauth handshake fail.
 
@@ -205,8 +203,6 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None, strea
     user_agent : str
         The user agent that is requesting the download.
         E.g. harmony/0.0.0 (harmony-sit) harmony-service-lib/4.0 (gdal-subsetter)
-    stream : boolean
-        Flag which will be passed to requests module when making download request
 
     Returns
     -------
@@ -218,9 +214,9 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None, strea
         headers['user-agent'] = user_agent
     auth = requests.auth.HTTPBasicAuth(config.edl_username, config.edl_password)
     if data is None:
-        return requests.get(url, stream=stream, headers=headers, timeout=TIMEOUT, auth=auth)
+        return requests.get(url, headers=headers, timeout=TIMEOUT, auth=auth, **kwargs)
     else:
-        return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth)
+        return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth, **kwargs)
 
 
 def _log_download_performance(logger, url, duration_ms, file_size):

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -214,7 +214,7 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None):
         headers['user-agent'] = user_agent
     auth = requests.auth.HTTPBasicAuth(config.edl_username, config.edl_password)
     if data is None:
-        return requests.get(url, headers=headers, timeout=TIMEOUT, auth=auth)
+        return requests.get(url, stream=True, headers=headers, timeout=TIMEOUT, auth=auth)
     else:
         return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth)
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -259,7 +259,7 @@ def _log_download_performance(logger, url, duration_ms, file_size):
 
 
 def download(config, url: str, access_token: str, data, destination_file,
-             user_agent=None, stream=True, chunk_size=1024*1024*16):
+             user_agent=None, stream=True, buffer_size=1024*1024*16):
     """Downloads the given url using the provided EDL user access token
     and writes it to the provided file-like object.
 
@@ -313,12 +313,12 @@ def download(config, url: str, access_token: str, data, destination_file,
     start_time = datetime.datetime.now()
     logger.info(f'timing.download.start {url}')
 
-    if (not stream) and chunk_size:
+    if (not stream) and buffer_size:
         logger.warn(
-            f"In download paramters, chunk_size={chunk_size} will be ignored since stream is set to be {stream}."
+            f"In download paramters, buffer_size={buffer_size} will be ignored since stream is set to be {stream}."
         )
-    elif stream and not isinstance(chunk_size, int):
-        raise Exception(f"In download parameters: chunk_size must be integer when stream={stream}.")
+    elif stream and not isinstance(buffer_size, int):
+        raise Exception(f"In download parameters: buffer_size must be integer when stream={stream}.")
 
     if access_token is not None and _valid(config.oauth_host, config.oauth_client_id, access_token):
         response = _download(config, url, access_token, data, user_agent, stream=stream)
@@ -335,7 +335,7 @@ def download(config, url: str, access_token: str, data, destination_file,
             destination_file.write(response.content)
             file_size = sys.getsizeof(response.content)
         else:
-            for chunk in response.iter_content(chunk_size=chunk_size):
+            for chunk in response.iter_content(chunk_size=buffer_size):
                 destination_file.write(chunk)
             file_size = os.path.getsize(destination_file.name)
         time_diff = datetime.datetime.now() - start_time

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -312,6 +312,9 @@ def download(config, url: str, access_token: str, data, destination_file,
     start_time = datetime.datetime.now()
     logger.info(f'timing.download.start {url}')
 
+    if bool(stream) != bool(chunk_size):
+        raise Exception(f'Mis-configured download parameters: stream={stream} and chunk_size={chunk_size}.')
+
     if access_token is not None and _valid(config.oauth_host, config.oauth_client_id, access_token):
         response = _download(config, url, access_token, data, user_agent, stream=stream)
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -313,8 +313,12 @@ def download(config, url: str, access_token: str, data, destination_file,
     start_time = datetime.datetime.now()
     logger.info(f'timing.download.start {url}')
 
-    if bool(stream) != bool(chunk_size):
-        raise Exception(f'Mis-configured download parameters: stream={stream} and chunk_size={chunk_size}.')
+    if (not stream) and chunk_size:
+        logger.warn(
+            f"In download paramters, chunk_size={chunk_size} will be ignored since stream is set to be {stream}."
+        )
+    elif stream and not isinstance(chunk_size, int):
+        raise Exception(f"In download parameters: chunk_size must be integer when stream={stream}.")
 
     if access_token is not None and _valid(config.oauth_host, config.oauth_client_id, access_token):
         response = _download(config, url, access_token, data, user_agent, stream=stream)

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -180,7 +180,7 @@ def _download(config, url: str, access_token: str, data, user_agent=None, **kwar
             # Including this header since the stdlib does by default,
             # but we've switched to `requests` which does not.
             headers['Content-Type'] = 'application/x-www-form-urlencoded'
-            return session.post(url, headers=headers, data=data, timeout=TIMEOUT, **kwargs_download_agent)
+            return session.post(url, headers=headers, data=data, timeout=TIMEOUT)
 
 
 def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwargs_download_agent):
@@ -222,7 +222,7 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwa
     if data is None:
         return requests.get(url, headers=headers, timeout=TIMEOUT, auth=auth, **kwargs_download_agent)
     else:
-        return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth, **kwargs_download_agent)
+        return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth)
 
 
 def _log_download_performance(logger, url, duration_ms, file_size):

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -14,7 +14,6 @@ from functools import lru_cache
 import json
 from urllib.parse import urlparse
 import datetime
-import sys
 import os
 import re
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -135,7 +135,7 @@ def _earthdata_session():
     return EarthdataSession()
 
 
-def _download(config, url: str, access_token: str, data, user_agent=None, **kwargs_download_agent):
+def _download(config, url: str, access_token: str, data, user_agent=None, **download_kwargs):
     """Implements the download functionality.
 
     Using the EarthdataSession and EarthdataAuth extensions to the
@@ -160,7 +160,7 @@ def _download(config, url: str, access_token: str, data, user_agent=None, **kwar
     user_agent : str
         The user agent that is requesting the download.
         E.g. harmony/0.0.0 (harmony-sit) harmony-service-lib/4.0 (gdal-subsetter)
-    kwargs_download_agent: dict
+    download_kwargs: dict
         kwargs to be passed to the download agent
         E.g. stream=True
 
@@ -176,7 +176,7 @@ def _download(config, url: str, access_token: str, data, user_agent=None, **kwar
     with _earthdata_session() as session:
         session.auth = auth
         if data is None:
-            return session.get(url, headers=headers, timeout=TIMEOUT, **kwargs_download_agent)
+            return session.get(url, headers=headers, timeout=TIMEOUT, **download_kwargs)
         else:
             # Including this header since the stdlib does by default,
             # but we've switched to `requests` which does not.
@@ -184,7 +184,7 @@ def _download(config, url: str, access_token: str, data, user_agent=None, **kwar
             return session.post(url, headers=headers, data=data, timeout=TIMEOUT)
 
 
-def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwargs_download_agent):
+def _download_with_fallback_authn(config, url: str, data, user_agent=None, **download_kwargs):
     """Downloads the given url using Basic authentication as a fallback
     mechanism should the normal EDL Oauth handshake fail.
 
@@ -207,7 +207,7 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwa
     user_agent : str
         The user agent that is requesting the download.
         E.g. harmony/0.0.0 (harmony-sit) harmony-service-lib/4.0 (gdal-subsetter)
-    kwargs_download_agent: dict
+    download_kwargs: dict
         kwargs to be passed to the download agent
         E.g. stream=True
 
@@ -221,7 +221,7 @@ def _download_with_fallback_authn(config, url: str, data, user_agent=None, **kwa
         headers['user-agent'] = user_agent
     auth = requests.auth.HTTPBasicAuth(config.edl_username, config.edl_password)
     if data is None:
-        return requests.get(url, headers=headers, timeout=TIMEOUT, auth=auth, **kwargs_download_agent)
+        return requests.get(url, headers=headers, timeout=TIMEOUT, auth=auth, **download_kwargs)
     else:
         return requests.post(url, headers=headers, data=data, timeout=TIMEOUT, auth=auth)
 
@@ -258,8 +258,34 @@ def _log_download_performance(logger, url, duration_ms, file_size):
     logger.info('timing.download.end', extra=extra_fields)
 
 
+def _preprocess_download_kwargs(download_kwargs: dict, logger):
+    """Preprocess the download kwargs.
+
+    Parameters
+    ----------
+    download_kwargs: dict
+        kwargs to be passed to the download agent
+        E.g. stream=True
+    logger : logging.Logger
+        The logger to use.
+    NOTE: By default, streaming request is used to download the file,
+          and the chunksize is set to be 16MB based on the experiment with a large file of 1.8Gb
+          for optimized speed and memory consumption.
+    """
+    download_kwargs.setdefault('stream', True)
+    download_kwargs.setdefault('chunk_size', 1024*1024*16)
+    stream = download_kwargs['stream'] if 'stream' in download_kwargs else False
+    chunk_size = download_kwargs['chunk_size'] if 'chunk_size' in download_kwargs else None
+    if (not stream) and chunk_size:
+        logger.warn(
+            f"In download paramters, chunk_size={chunk_size} will be ignored since stream is set to be {stream}."
+        )
+    elif stream and not isinstance(chunk_size, int):
+        raise Exception(f"In download parameters: chunk_size must be integer when stream={stream}.")
+
+
 def download(config, url: str, access_token: str, data, destination_file,
-             user_agent=None, stream=True, chunk_size=1024*1024*16):
+             user_agent=None, **download_kwargs):
     """Downloads the given url using the provided EDL user access token
     and writes it to the provided file-like object.
 
@@ -303,9 +329,6 @@ def download(config, url: str, access_token: str, data, destination_file,
     Side-effects
     ------------
     Will write to provided destination_file
-    NOTE: streaming request is used to download the file,
-          and the chunksize is defaulted to 16MB based on the experiment with a large file of 1.8Gb
-          for optimized speed and memory consumption.
     """
 
     response = None
@@ -313,25 +336,24 @@ def download(config, url: str, access_token: str, data, destination_file,
     start_time = datetime.datetime.now()
     logger.info(f'timing.download.start {url}')
 
-    if bool(stream) != bool(chunk_size):
-        raise Exception(f'Mis-configured download parameters: stream={stream} and chunk_size={chunk_size}.')
+    _preprocess_download_kwargs(download_kwargs, logger)
 
     if access_token is not None and _valid(config.oauth_host, config.oauth_client_id, access_token):
-        response = _download(config, url, access_token, data, user_agent, stream=stream)
+        response = _download(config, url, access_token, data, user_agent, stream=download_kwargs["stream"])
 
     if response is None or not response.ok:
         if config.fallback_authn_enabled:
             msg = ('No valid user access token in request or EDL OAuth authentication failed.'
                    'Fallback authentication enabled: retrying with Basic auth.')
             logger.warning(msg)
-            response = _download_with_fallback_authn(config, url, data, user_agent, stream=stream)
+            response = _download_with_fallback_authn(config, url, data, user_agent, stream=download_kwargs["stream"])
 
     if response.ok:
-        if not stream:
+        if not download_kwargs["stream"]:
             destination_file.write(response.content)
             file_size = sys.getsizeof(response.content)
         else:
-            for chunk in response.iter_content(chunk_size=chunk_size):
+            for chunk in response.iter_content(chunk_size=download_kwargs["chunk_size"]):
                 destination_file.write(chunk)
             file_size = os.path.getsize(destination_file.name)
         time_diff = datetime.datetime.now() - start_time

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -298,7 +298,8 @@ def test_when_authn_succeeds_it_writes_to_provided_file(
         mocker,
         access_token,
         resource_server_granule_url,
-        response_body_from_granule_url):
+        response_body_from_granule_url,
+        getsize_patched):
 
     monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
     responses.add(
@@ -310,7 +311,6 @@ def test_when_authn_succeeds_it_writes_to_provided_file(
     destination_file = mocker.Mock()
     cfg = config_fixture()
 
-    monkeypatch.setattr(os.path, "getsize", lambda a: len(response_body_from_granule_url))
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
 
     assert response.status_code == 200
@@ -324,7 +324,8 @@ def test_when_given_an_access_token_and_error_occurs_it_falls_back_to_basic_auth
         mocker,
         faker,
         resource_server_granule_url,
-        response_body_from_granule_url):
+        response_body_from_granule_url,
+        getsize_patched):
 
     monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
     client_id = faker.password(length=22, special_chars=False)
@@ -344,7 +345,6 @@ def test_when_given_an_access_token_and_error_occurs_it_falls_back_to_basic_auth
     )
     destination_file = mocker.Mock()
 
-    monkeypatch.setattr(os.path, "getsize", lambda a: len(response_body_from_granule_url))
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
 
     assert response.status_code == 200
@@ -386,7 +386,8 @@ def test_when_no_access_token_is_provided_it_uses_basic_auth_and_downloads_when_
         mocker,
         faker,
         resource_server_granule_url,
-        response_body_from_granule_url):
+        response_body_from_granule_url,
+        getsize_patched):
 
     client_id = faker.password(length=22, special_chars=False)
     cfg = config_fixture(oauth_client_id=client_id, fallback_authn_enabled=True)
@@ -399,7 +400,6 @@ def test_when_no_access_token_is_provided_it_uses_basic_auth_and_downloads_when_
     )
     destination_file = mocker.Mock()
 
-    monkeypatch.setattr(os.path, "getsize", lambda a: len(response_body_from_granule_url))
     response = download(cfg, resource_server_granule_url, None, None, destination_file)
 
     assert response.status_code == 200

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -8,6 +8,7 @@ from tests.util import config_fixture
 
 EDL_URL = 'https://uat.urs.earthdata.nasa.gov'
 
+
 @pytest.mark.parametrize('url,expected', [
     ('http://example.com', True),
     ('HTTP://YELLING.COM', True),

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -284,6 +284,7 @@ def test_when_authn_succeeds_it_writes_to_provided_file(
     responses.add(
         responses.GET,
         resource_server_granule_url,
+        body='dummy response body',
         status=200
     )
     destination_file = mocker.Mock()
@@ -316,6 +317,7 @@ def test_when_given_an_access_token_and_error_occurs_it_falls_back_to_basic_auth
     responses.add(
         responses.GET,
         resource_server_granule_url,
+        body='dummy response body',
         status=200
     )
     destination_file = mocker.Mock()
@@ -367,6 +369,7 @@ def test_when_no_access_token_is_provided_it_uses_basic_auth_and_downloads_when_
     responses.add(
         responses.GET,
         resource_server_granule_url,
+        body='dummy response body',
         status=200
     )
     destination_file = mocker.Mock()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -380,7 +380,6 @@ def test_when_given_an_access_token_and_error_occurs_it_does_not_fall_back_to_ba
 
 @responses.activate
 def test_when_no_access_token_is_provided_it_uses_basic_auth_and_downloads_when_enabled(
-        monkeypatch,
         mocker,
         faker,
         resource_server_granule_url,
@@ -433,7 +432,6 @@ def test_download_unknown_error_exception_if_all_else_fails(
 
 @responses.activate
 def test_user_agent_is_passed_to_request_headers_when_using_basic_auth(
-        monkeypatch,
         mocker,
         faker,
         resource_server_granule_url,
@@ -457,7 +455,6 @@ def test_user_agent_is_passed_to_request_headers_when_using_basic_auth(
 
 @responses.activate
 def test_user_agent_is_passed_to_request_headers_when_using_basic_auth_and_post_param(
-        monkeypatch,
         mocker,
         faker,
         resource_server_granule_url,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -186,7 +186,6 @@ def test_resource_server_redirects_to_granule_url(
 
 @responses.activate
 def test_download_validates_token(
-        monkeypatch,
         mocker,
         faker,
         access_token,
@@ -214,7 +213,6 @@ def test_download_validates_token(
 
 @responses.activate
 def test_download_validates_token_once(
-        monkeypatch,
         mocker,
         faker,
         validate_access_token_url,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,12 +1,12 @@
 import pytest
 import responses
+import os
 
 import harmony.http
 from harmony.http import (download, is_http, localhost_url)
 from tests.util import config_fixture
 
 EDL_URL = 'https://uat.urs.earthdata.nasa.gov'
-
 
 @pytest.mark.parametrize('url,expected', [
     ('http://example.com', True),
@@ -51,6 +51,11 @@ def resource_server_granule_url():
 
 
 @pytest.fixture
+def response_body_from_granule_url():
+    return "dummy response body"
+
+
+@pytest.fixture
 def resource_server_redirect_url(faker):
     return ('https://n5eil11u.ecs.nsidc.org/TS1_redirect'
             f'?code={faker.password(length=64, special_chars=False)}'
@@ -89,6 +94,7 @@ def test_download_follows_redirect_to_edl_and_adds_auth_headers(
     destination_file = mocker.Mock()
     cfg = config_fixture()
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
 
     # We should get redirected to EDL
@@ -129,6 +135,7 @@ def test_download_follows_redirect_to_resource_server_with_code(
     destination_file = mocker.Mock()
     cfg = config_fixture()
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, edl_redirect_url, access_token, None, destination_file)
 
     assert response.status_code == 302
@@ -162,6 +169,7 @@ def test_resource_server_redirects_to_granule_url(
     destination_file = mocker.Mock()
     cfg = config_fixture()
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_redirect_url, access_token, None, destination_file)
 
     assert response.status_code == 303
@@ -172,6 +180,7 @@ def test_resource_server_redirects_to_granule_url(
 
 @responses.activate
 def test_download_validates_token(
+        monkeypatch,
         mocker,
         faker,
         access_token,
@@ -189,6 +198,7 @@ def test_download_validates_token(
     responses.add(responses.GET, resource_server_granule_url, status=200)
     destination_file = mocker.Mock()
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
 
     assert response.status_code == 200
@@ -198,6 +208,7 @@ def test_download_validates_token(
 
 @responses.activate
 def test_download_validates_token_once(
+        monkeypatch,
         mocker,
         faker,
         validate_access_token_url,
@@ -216,6 +227,7 @@ def test_download_validates_token_once(
     responses.add(responses.GET, resource_server_granule_url, status=200)
     destination_file = mocker.Mock()
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
 
@@ -266,6 +278,7 @@ def test_when_given_a_url_and_data_it_downloads_with_query_parameters(
     cfg = config_fixture()
     data = {'param': 'value'}
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_granule_url, access_token, data, destination_file)
 
     assert response.status_code == 200
@@ -278,18 +291,20 @@ def test_when_authn_succeeds_it_writes_to_provided_file(
         monkeypatch,
         mocker,
         access_token,
-        resource_server_granule_url):
+        resource_server_granule_url,
+        response_body_from_granule_url):
 
     monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
     responses.add(
         responses.GET,
         resource_server_granule_url,
-        body='dummy response body',
+        body=response_body_from_granule_url,
         status=200
     )
     destination_file = mocker.Mock()
     cfg = config_fixture()
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: len(response_body_from_granule_url))
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
 
     assert response.status_code == 200
@@ -302,7 +317,8 @@ def test_when_given_an_access_token_and_error_occurs_it_falls_back_to_basic_auth
         monkeypatch,
         mocker,
         faker,
-        resource_server_granule_url):
+        resource_server_granule_url,
+        response_body_from_granule_url):
 
     monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
     client_id = faker.password(length=22, special_chars=False)
@@ -317,11 +333,12 @@ def test_when_given_an_access_token_and_error_occurs_it_falls_back_to_basic_auth
     responses.add(
         responses.GET,
         resource_server_granule_url,
-        body='dummy response body',
+        body=response_body_from_granule_url,
         status=200
     )
     destination_file = mocker.Mock()
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: len(response_body_from_granule_url))
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
 
     assert response.status_code == 200
@@ -359,9 +376,11 @@ def test_when_given_an_access_token_and_error_occurs_it_does_not_fall_back_to_ba
 
 @responses.activate
 def test_when_no_access_token_is_provided_it_uses_basic_auth_and_downloads_when_enabled(
+        monkeypatch,
         mocker,
         faker,
-        resource_server_granule_url):
+        resource_server_granule_url,
+        response_body_from_granule_url):
 
     client_id = faker.password(length=22, special_chars=False)
     cfg = config_fixture(oauth_client_id=client_id, fallback_authn_enabled=True)
@@ -369,11 +388,12 @@ def test_when_no_access_token_is_provided_it_uses_basic_auth_and_downloads_when_
     responses.add(
         responses.GET,
         resource_server_granule_url,
-        body='dummy response body',
+        body=response_body_from_granule_url,
         status=200
     )
     destination_file = mocker.Mock()
 
+    monkeypatch.setattr(os.path, "getsize", lambda a: len(response_body_from_granule_url))
     response = download(cfg, resource_server_granule_url, None, None, destination_file)
 
     assert response.status_code == 200
@@ -409,6 +429,7 @@ def test_download_unknown_error_exception_if_all_else_fails(
 
 @responses.activate
 def test_user_agent_is_passed_to_request_headers_when_using_basic_auth(
+        monkeypatch,
         mocker,
         faker,
         resource_server_granule_url):
@@ -424,6 +445,7 @@ def test_user_agent_is_passed_to_request_headers_when_using_basic_auth(
     destination_file = mocker.Mock()
 
     user_agent = 'test-agent/0.0.0'
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_granule_url, None, None, destination_file, user_agent=user_agent)
 
     assert 'User-Agent' in responses.calls[0].request.headers
@@ -431,6 +453,7 @@ def test_user_agent_is_passed_to_request_headers_when_using_basic_auth(
 
 @responses.activate
 def test_user_agent_is_passed_to_request_headers_when_using_basic_auth_and_post_param(
+        monkeypatch,
         mocker,
         faker,
         resource_server_granule_url):
@@ -447,6 +470,7 @@ def test_user_agent_is_passed_to_request_headers_when_using_basic_auth_and_post_
     destination_file = mocker.Mock()
 
     user_agent = 'test-agent/0.0.0'
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_granule_url, None, data, destination_file, user_agent=user_agent)
 
     assert 'User-Agent' in responses.calls[0].request.headers
@@ -469,6 +493,7 @@ def test_user_agent_is_passed_to_request_headers_when_using_edl_auth(
     cfg = config_fixture()
 
     user_agent = 'test-agent/0.0.0'
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file, user_agent=user_agent)
 
     assert 'User-Agent' in responses.calls[0].request.headers
@@ -492,6 +517,7 @@ def test_user_agent_is_passed_to_request_headers_when_using_edl_auth_and_post_pa
     data = {'param': 'value'}
 
     user_agent = 'test-agent/0.0.0'
+    monkeypatch.setattr(os.path, "getsize", lambda a: 0)
     response = download(cfg, resource_server_granule_url, access_token, data, destination_file, user_agent=user_agent)
 
     assert 'User-Agent' in responses.calls[0].request.headers


### PR DESCRIPTION
This PR is trying to fix the out-of-memory error when processing some large granules from netcdf-to-zarr service.

It mainly addresses the memory issue during downloading step by using streaming request with optimized chunksize to balance download speed and memory consumption. The detailed experiments is summarized in the comment of JIRA story 838.

With this PR, the 1.8 GB benchmark from story-838 should be able to be processed with the current resource configuration in NGAP2 (4 GB instance type).

For local deployment, this benchmark would need at least 4.5 GB memory for docker configuration due to the memory overhead in localstack container.