### PR TITLE
HARMONY-802: use python-json-logger 2.0.1 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ boto3 ~= 1.14
 deprecation ~= 2.1.0
 pynacl ~= 1.4
 pystac ~= 0.5.3
-python-json-logger ~= 0.1
+python-json-logger ~= 2.0.1
 requests ~= 2.24


### PR DESCRIPTION
This PR simply replace the version of python-json-logger by 2.0.1. I was trying to reproduce the warning message as mentioned in story https://bugs.earthdata.nasa.gov/browse/HARMONY-802, but don't see any, so it will be great if somebody can confirm with me about that.