### PR TITLE
HARMONY-1156: Support 0.15.0 of the data operation schema - coordinate variables

### DIFF
--- a/example/example_message.json
+++ b/example/example_message.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "../../harmony/app/schemas/data-operation/0.14.0/data-operation-v0.14.0.json",
-  "version": "0.14.0",
+  "$schema": "../../harmony/app/schemas/data-operation/0.15.0/data-operation-v0.15.0.json",
+  "version": "0.15.0",
   "callback": "http://localhost/some-path",
   "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
   "user": "jdoe",
@@ -8,11 +8,9 @@
   "client": "harmony-example",
   "requestId": "00001111-2222-3333-4444-555566667777",
   "accessToken": "ABCD1234567890",
-  "sources": [
-    {
+  "sources": [{
       "collection": "C1233800302-EEDTEST",
-      "variables": [
-        {
+      "variables": [{
           "id": "V0001-EXAMPLE",
           "name": "ExampleVar",
           "fullPath": "example/group/path/ExampleVar",
@@ -24,9 +22,17 @@
             "url": "http://example.com/file649.txt",
             "mimeType": "text/plain",
             "format": "ASCII"
-          }]
-        }
-      ]
+          }],
+          "type": "SCIENCE_VARIABLE",
+          "subtype": "SCIENCE_ARRAY"
+      }],
+      "coordinateVariables": [{
+        "id": "V1233801718-EEDTEST",
+        "name": "lat",
+        "fullPath": "lat",
+        "type": "COORDINATE",
+        "subtype": "LATITUDE"
+      }]
     }
   ],
   "format": {

--- a/harmony/message.py
+++ b/harmony/message.py
@@ -99,8 +99,8 @@ class JsonObject(object):
 
 class Source(JsonObject):
     """
-    A collection / granule / variable data source as found in the Harmony message
-    "sources" list.
+    A collection / granule / variable / coordinateVariable data source as found in
+    the Harmony message "sources" list.
 
     Attributes
     ----------
@@ -108,6 +108,9 @@ class Source(JsonObject):
         The id of the collection the data source's variables and granules are in
     variables : list
         A list of Variable objects for the variables which should be transformed
+    coordinateVariables: list
+        A list of Variable objects containing the coordinate variables for the
+        collection.
     granules : list
         A list of Granule objects for the granules which should be operated on
     """
@@ -124,7 +127,10 @@ class Source(JsonObject):
         super().__init__(message_data,
                          properties=['collection'],
                          list_properties={
-                             'variables': Variable, 'granules': Granule}
+                             'variables': Variable,
+                             'coordinateVariables': Variable,
+                             'granules': Granule
+                            }
                          )
         for granule in self.granules:
             granule.collection = self.collection
@@ -156,11 +162,11 @@ class Variable(JsonObject):
         Parameters
         ----------
         message_data : dictionary
-            The Harmony message "variables" item to deserialize
+            The Harmony message "variables" or "coordinateVariables" item to deserialize
         """
         super().__init__(
             message_data,
-            properties=['id', 'name', 'fullPath'],
+            properties=['id', 'name', 'fullPath', 'type', 'subtype'],
             list_properties={
                 'relatedUrls': RelatedUrl
             })

--- a/tests/example_messages.py
+++ b/tests/example_messages.py
@@ -1,7 +1,7 @@
 minimal_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.14.0/data-operation-v0.14.0.json",
-        "version": "0.14.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.15.0/data-operation-v0.15.0.json",
+        "version": "0.15.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -19,8 +19,8 @@ minimal_message = """
 
 minimal_source_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.14.0/data-operation-v0.14.0.json",
-        "version": "0.14.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.15.0/data-operation-v0.15.0.json",
+        "version": "0.15.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -31,6 +31,7 @@ minimal_source_message = """
             {
             "collection": "C0001-EXAMPLE",
             "variables": [],
+            "coordinateVariables": [],
             "granules": []
             }
         ],
@@ -43,8 +44,8 @@ minimal_source_message = """
 
 full_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.14.0/data-operation-v0.14.0.json",
-        "version": "0.14.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.15.0/data-operation-v0.15.0.json",
+        "version": "0.15.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -52,11 +53,9 @@ full_message = """
         "requestId": "00001111-2222-3333-4444-555566667777",
         "isSynchronous": true,
         "accessToken": "ABCD1234567890",
-        "sources": [
-            {
+        "sources": [{
             "collection": "C0001-EXAMPLE",
-            "variables": [
-                {
+            "variables": [{
                 "id": "V0001-EXAMPLE",
                 "name": "ExampleVar1",
                 "fullPath": "example/path/ExampleVar1",
@@ -68,9 +67,17 @@ full_message = """
                     "url": "http://example.com/file649.txt",
                     "mimeType": "text/plain",
                     "format": "ASCII"
-                    }]
-                }
-            ],
+                }],
+                "type": "SCIENCE_VARIABLE",
+                 "subtype": "SCIENCE_ARRAY"
+            }],
+            "coordinateVariables": [{
+              "id": "V1233801718-EEDTEST",
+              "name": "lat",
+              "fullPath": "lat",
+              "type": "COORDINATE",
+              "subtype": "LATITUDE"
+            }],
             "granules": [
                 {
                 "id": "G0001-EXAMPLE",

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -13,7 +13,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_full_message_it_parses_it_into_objects(self):
         message = Message(full_message)
 
-        self.assertEqual(message.version, '0.14.0')
+        self.assertEqual(message.version, '0.15.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -26,6 +26,8 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.sources[0].variables[0].id, 'V0001-EXAMPLE')
         self.assertEqual(message.sources[0].variables[0].name, 'ExampleVar1')
         self.assertEqual(message.sources[0].variables[0].fullPath, 'example/path/ExampleVar1')
+        self.assertEqual(message.sources[0].variables[0].type, 'SCIENCE_VARIABLE')
+        self.assertEqual(message.sources[0].variables[0].subtype, 'SCIENCE_ARRAY')
         self.assertEqual(message.sources[0].variables[0].relatedUrls[0].urlContentType, 'DistributionURL')
         self.assertEqual(message.sources[0].variables[0].relatedUrls[0].type, 'GET DATA')
         self.assertEqual(message.sources[0].variables[0].relatedUrls[0].subtype, 'EOSDIS DATA POOL')
@@ -33,6 +35,11 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.sources[0].variables[0].relatedUrls[0].url, 'http://example.com/file649.txt')
         self.assertEqual(message.sources[0].variables[0].relatedUrls[0].mimeType, 'text/plain')
         self.assertEqual(message.sources[0].variables[0].relatedUrls[0].format, 'ASCII')
+        self.assertEqual(message.sources[0].coordinateVariables[0].id, 'V1233801718-EEDTEST')
+        self.assertEqual(message.sources[0].coordinateVariables[0].name, 'lat')
+        self.assertEqual(message.sources[0].coordinateVariables[0].fullPath, 'lat')
+        self.assertEqual(message.sources[0].coordinateVariables[0].type, 'COORDINATE')
+        self.assertEqual(message.sources[0].coordinateVariables[0].subtype, 'LATITUDE')
         self.assertEqual(message.sources[0].granules[1].id, 'G0002-EXAMPLE')
         self.assertEqual(message.sources[0].granules[1].name, 'Example2')
         self.assertEqual(message.sources[0].granules[1].url, 'file://example/example_granule_2.txt')
@@ -65,7 +72,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_minimal_message_it_parses_it_into_objects(self):
         message = Message(minimal_message)
 
-        self.assertEqual(message.version, '0.14.0')
+        self.assertEqual(message.version, '0.15.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -84,12 +91,13 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_message_with_minimal_source_it_parses_it_into_objects(self):
         message = Message(minimal_source_message)
 
-        self.assertEqual(message.version, '0.14.0')
+        self.assertEqual(message.version, '0.15.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.user, 'jdoe')
         self.assertEqual(message.accessToken, 'ABCD1234567890')
         self.assertEqual(message.sources[0].collection, 'C0001-EXAMPLE')
         self.assertEqual(message.sources[0].variables, [])
+        self.assertEqual(message.sources[0].coordinateVariables, [])
         self.assertEqual(message.sources[0].granules, [])
 
     def test_granules_attribute_returns_all_child_granules(self):


### PR DESCRIPTION
## Jira Issue ID

HARMONY-1156

## Description

Supports the 0.15.0 of the data operation schema (added in HARMONY-1121) which adds coordinate variables and include type and subtype fields for variables.

## Local Test Steps
There is not a service making use of these changes yet. Run the unit tests and make sure they pass. You could build a harmony-service-example with this updated library and then print out the message that gets passed in with:
http://localhost:3000/C1243747507-EEDTEST/ogc-api-coverages/1.0.0/collections/sea_surface_temperature/coverage/rangeset?subset=lat(-45%3A45)&subset=lon(0%3A180)&maxResults=1&format=image/png

to make sure the fields are parsed correctly. Note that the request will fail though (unrelated to the variables change).

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)