### PR TITLE
HARMONY-1178: Add handling of paged STAC catalogs

### DIFF
--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -189,7 +189,7 @@ def _build_adapter(AdapterClass, message_string, sources_path, data_location, co
 def _invoke(adapter, metadata_dir):
     """
     Handles --harmony-action=invoke by invoking the adapter for the given input message
-
+vim 
     Parameters
     ----------
     adapter : BaseHarmonyAdapter

--- a/tests/test_adapter_stac.py
+++ b/tests/test_adapter_stac.py
@@ -4,6 +4,7 @@ Tests STAC-based invocation styles and methods on BaseHarmonyAdapter
 
 import unittest
 
+from unittest.mock import patch
 from pystac import Catalog, Item, Link
 
 from harmony.message import Message
@@ -51,6 +52,32 @@ class TestBaseHarmonyAdapterDefaultInvoke(unittest.TestCase):
         self.assertEqual(AdapterTester.process_args[0][1], message.sources[0])
         self.assertEqual(AdapterTester.process_args[1][1], message.sources[0])
 
+    @patch('harmony.adapter.read_file')
+    def test_invocation_follows_linked_catalogs(self, test_patch):
+        catalog0 = Catalog('0', 'Catalog 0')
+        catalog0.add_link(Link('harmony_source', 'http://example.com/C0001-EXAMPLE'))
+        catalog1 = Catalog('1', 'Catalog 1')
+        catalog1.add_link(Link('harmony_source', 'http://example.com/C0002-EXAMPLE'))
+        catalog0.add_link(Link('next', 'catalog1.json'))
+        test_patch.return_value = catalog1
+        message = Message(full_message)
+        items_a = [
+            Item('3', None, [0, 0, 1, 3], '2020-01-01T00:00:00.000Z', {}),
+            Item('4', None, [0, 0, 1, 4], '2020-01-01T00:00:00.000Z', {})
+        ]
+        items_b = [
+            Item('5', None, [0, 0, 1, 5], '2020-01-01T00:00:00.000Z', {}),
+            Item('6', None, [0, 0, 1, 6], '2020-01-01T00:00:00.000Z', {})
+        ]
+        catalog0.add_items(items_a)
+        catalog1.add_items(items_b)
+        adapter = AdapterTester(message, catalog0, config=self.config)
+        adapter.invoke()
+        self.assertEqual(AdapterTester.process_args[0][0].bbox, items_a[0].bbox)
+        self.assertEqual(AdapterTester.process_args[1][0].bbox, items_a[1].bbox)
+        self.assertEqual(AdapterTester.process_args[2][0].bbox, items_b[0].bbox)
+        self.assertEqual(AdapterTester.process_args[3][0].bbox, items_b[1].bbox)
+
     def test_invocation_recurses_subcatalogs(self):
         catalog = Catalog('0', 'Catalog 0')
         catalog.add_link(Link('harmony_source', 'http://example.com/C0001-EXAMPLE'))
@@ -83,6 +110,56 @@ class TestBaseHarmonyAdapterDefaultInvoke(unittest.TestCase):
         self.assertEqual(AdapterTester.process_args[1][1], message.sources[0])
         self.assertEqual(AdapterTester.process_args[2][1], message.sources[1])
         self.assertEqual(AdapterTester.process_args[3][1], message.sources[1])
+
+    @patch('harmony.adapter.read_file')
+    def test_get_all_items_follows_links(self, test_patch):
+        catalog0 = Catalog('0', 'Catalog 0')
+        catalog0.add_link(Link('harmony_source', 'http://example.com/C0001-EXAMPLE'))
+        catalog1 = Catalog('1', 'Catalog 1')
+        catalog1.add_link(Link('harmony_source', 'http://example.com/C0002-EXAMPLE'))
+        catalog0.add_link(Link('next', 'catalog1.json'))
+        test_patch.return_value = catalog1
+        message = Message(full_message)
+        items_a = [
+            Item('3', None, [0, 0, 1, 3], '2020-01-01T00:00:00.000Z', {}),
+            Item('4', None, [0, 0, 1, 4], '2020-01-01T00:00:00.000Z', {})
+        ]
+        items_b = [
+            Item('5', None, [0, 0, 1, 5], '2020-01-01T00:00:00.000Z', {}),
+            Item('6', None, [0, 0, 1, 6], '2020-01-01T00:00:00.000Z', {})
+        ]
+        catalog0.add_items(items_a)
+        catalog1.add_items(items_b)
+        adapter = AdapterTester(message, catalog0, config=self.config)
+        all_items = list(adapter.get_all_catalog_items(catalog0, True))
+        self.assertEqual(all_items, [ *items_a, *items_b ])
+
+    @patch('harmony.adapter.read_file')
+    def test_get_all_items_handles_children(self, test_patch):
+        catalog = Catalog('0', 'Catalog 0')
+        catalog.add_link(Link('harmony_source', 'http://example.com/C0001-EXAMPLE'))
+        catalog.add_child(Catalog('1a', 'Catalog 1a'))
+        subcatalog = Catalog('1b', 'Catalog 1b')
+        catalog.add_child(subcatalog)
+        subsubcatalog_a = Catalog('2a', 'Catalog 2a')
+        subsubcatalog_b = Catalog('2b', 'Catalog 2b')
+        subsubcatalog_b.add_link(Link('harmony_source', 'http://example.com/C0002-EXAMPLE'))
+        subcatalog.add_children([subsubcatalog_a, subsubcatalog_b])
+
+        message = Message(full_message)
+        items_a = [
+            Item('3', None, [0, 0, 1, 3], '2020-01-01T00:00:00.000Z', {}),
+            Item('4', None, [0, 0, 1, 4], '2020-01-01T00:00:00.000Z', {})
+        ]
+        items_b = [
+            Item('5', None, [0, 0, 1, 5], '2020-01-01T00:00:00.000Z', {}),
+            Item('6', None, [0, 0, 1, 6], '2020-01-01T00:00:00.000Z', {})
+        ]
+        subsubcatalog_a.add_items(items_a)
+        subsubcatalog_b.add_items(items_b)
+        adapter = AdapterTester(message, catalog, config=self.config)
+        all_items = list(adapter.get_all_catalog_items(catalog, True))
+        self.assertEqual(all_items, [ *items_a, *items_b ])
 
     def test_unaltered_ids_are_assigned_new_uuids(self):
         catalog = Catalog('0', 'Catalog 0')


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1178

## Description
Adds handling of paged STAC catalos, i.e, catalogs that have 'next' and 'prev' links

## Local Test Steps
* WIP

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~