### PR TITLE
Harmony 1125 - Automatically retry temporary request failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ OPTIONAL:
        health check command. The container is considered unhealthy if the mtime of the file is old -
        where 'old' is configurable in the service container. If this variable is not set the path
        defaults to '/tmp/health.txt'.
+* `MAX_DOWNLOAD_RETRIES`: Number of times to retry failed HTTP calls via the http module.
 
 OPTIONAL -- Use with CAUTION:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ OPTIONAL:
        health check command. The container is considered unhealthy if the mtime of the file is old -
        where 'old' is configurable in the service container. If this variable is not set the path
        defaults to '/tmp/health.txt'.
-* `MAX_DOWNLOAD_RETRIES`: Number of times to retry failed HTTP calls via the http module.
+* `MAX_DOWNLOAD_RETRIES`: Number of times to retry HTTP download calls that fail due to transient errors.
 
 OPTIONAL -- Use with CAUTION:
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,6 @@ pytest ~= 6.2
 pytest-cov ~=2.11
 pytest-mock ~=3.5
 python-language-server ~= 0.35
-responses ~= 0.12
+responses @ git+https://github.com/getsentry/responses.git@bdc5eff7169a6fba730f2f8427d5ec5a817b1ad5
 safety ~= 1.8
 pycodestyle ~= 2.7.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ pytest ~= 6.2
 pytest-cov ~=2.11
 pytest-mock ~=3.5
 python-language-server ~= 0.35
+# change this to an official release once the code in this commit is released (https://github.com/getsentry/responses/releases)
 responses @ git+https://github.com/getsentry/responses.git@bdc5eff7169a6fba730f2f8427d5ec5a817b1ad5
 safety ~= 1.8
 pycodestyle ~= 2.7.0

--- a/harmony/exceptions.py
+++ b/harmony/exceptions.py
@@ -27,11 +27,13 @@ class ForbiddenException(HarmonyException):
     def __init__(self, message=None):
         super().__init__(message, 'Forbidden')
 
+
 class ServerException(HarmonyException):
     """Class for throwing an exception indicating the download failed due to a generic 500 internal server error """
 
     def __init__(self, message=None):
         super().__init__(message, 'Server')
+
 
 class TransientException(HarmonyException):
     """Class for throwing an exception indicating the download failed due to a transient HTTP error (e.g. 502) """

--- a/harmony/exceptions.py
+++ b/harmony/exceptions.py
@@ -26,3 +26,15 @@ class ForbiddenException(HarmonyException):
 
     def __init__(self, message=None):
         super().__init__(message, 'Forbidden')
+
+class ServerException(HarmonyException):
+    """Class for throwing an exception indicating the download failed due to a generic 500 internal server error """
+
+    def __init__(self, message=None):
+        super().__init__(message, 'Server')
+
+class TransientException(HarmonyException):
+    """Class for throwing an exception indicating the download failed due to a transient HTTP error (e.g. 502) """
+
+    def __init__(self, message=None):
+        super().__init__(message, 'Transient')

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -87,7 +87,8 @@ def _mount_retry(session, total_retries, backoff_factor=2):
         Upper limit on the number of times to retry the request
     backoff_factor: float
         Factor used to determine backoff/sleep time between executions:
-        backoff = {backoff factor} * (2 ** ({number of total retries} - 1))
+        backoff = {backoff factor} * (2 ** ({retry number} - 1))
+        where {retry number} = 1, 2, 3...
 
     Returns
     -------
@@ -104,13 +105,17 @@ def _retry_adapter(total_retries, backoff_factor=2):
     HTTP adapter for retrying failed requests that have returned a status code
     indicating a temporary error.
 
+    With a backoff_factor of 5, the total sleep seconds between executions will be:
+    [0, 0+10, 0+10+20, 0+10+20+40, ...]
+
     Parameters
     ----------
     total_retries: int
         Upper limit on the number of times to retry the request
     backoff_factor: float
         Factor used to determine backoff/sleep time between executions:
-        backoff = {backoff factor} * (2 ** ({number of total retries} - 1))
+        backoff = {backoff factor} * (2 ** ({retry number} - 1))
+        where {retry number} = 1, 2, 3...
 
     Returns
     -------

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -74,7 +74,7 @@ def localhost_url(url, local_hostname):
 
 
 def _mount_retry(session, total_retries, backoff_factor=2):
-    """Mount a retry adapter (with exponential backoff) to a requests session.
+    """Instantiates a retry adapter (with exponential backoff) and mounts it to the requests session.
 
     backoff = {backoff factor} * (2 ** ({retry number} - 1))
     where {retry number} = 1, 2, 3, ..., total_retries

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -37,7 +37,6 @@ TIMEOUT = 60
 # Error codes for which the retry adapter will retry failed requests.
 # Only requests sessions with a mounted retry adapter will exhibit retry behavior.
 RETRY_ERROR_CODES = (408, 502, 503, 504)
-DEFAULT_TOTAL_RETRIES = 10
 
 
 def is_http(url: str) -> bool:
@@ -391,7 +390,8 @@ def download(config, url: str, access_token: str, data, destination_file,
     elif stream and not isinstance(buffer_size, int):
         raise Exception(f"In download parameters: buffer_size must be integer when stream={stream}.")
 
-    if access_token is not None and _valid(config.oauth_host, config.oauth_client_id, access_token, config.max_download_retries):
+    if access_token is not None and _valid(
+            config.oauth_host, config.oauth_client_id, access_token, config.max_download_retries):
         response = _download(config, url, access_token, data, config.max_download_retries, user_agent, stream=stream)
 
     if response is None or not response.ok:
@@ -399,7 +399,8 @@ def download(config, url: str, access_token: str, data, destination_file,
             msg = ('No valid user access token in request or EDL OAuth authentication failed.'
                    'Fallback authentication enabled: retrying with Basic auth.')
             logger.warning(msg)
-            response = _download_with_fallback_authn(config, url, data, config.max_download_retries, user_agent, stream=stream)
+            response = _download_with_fallback_authn(
+                config, url, data, config.max_download_retries, user_agent, stream=stream)
 
     if response.ok:
         if not stream:

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -37,7 +37,7 @@ TIMEOUT = 60
 # Error codes for which the retry adapter will retry failed requests.
 # Only requests sessions with a mounted retry adapter will exhibit retry behavior.
 RETRY_ERROR_CODES = (408, 502, 503, 504)
-DEFAULT_TOTAL_RETRIES = 10  # per requests session
+DEFAULT_TOTAL_RETRIES = 10
 
 
 def is_http(url: str) -> bool:

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -34,9 +34,10 @@ from harmony.logging import build_logger
 # https://2.python-requests.org/en/master/user/quickstart/#timeouts
 TIMEOUT = 60
 
-# Error codes for which we should retry failed requests
+# Error codes for which the retry adapter will retry failed requests.
+# Only requests sessions with a mounted retry adapter will exhibit retry behavior.
 RETRY_ERROR_CODES = (408, 502, 503, 504)
-DEFAULT_TOTAL_RETRIES = 10
+DEFAULT_TOTAL_RETRIES = 10 # per requests session
 
 
 def is_http(url: str) -> bool:

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -73,7 +73,7 @@ def localhost_url(url, local_hostname):
     return url.replace('localhost', local_hostname)
 
 
-def _mount_retry(session, total_retries, backoff_factor=0.2):
+def _mount_retry(session, total_retries, backoff_factor=2):
     """Mount a retry adapter to a requests session.
 
     With a backoff_factor of 5, the total sleep seconds between executions will be:
@@ -99,7 +99,7 @@ def _mount_retry(session, total_retries, backoff_factor=0.2):
     return session
 
 
-def _retry_adapter(total_retries, backoff_factor=0.2):
+def _retry_adapter(total_retries, backoff_factor=2):
     """
     HTTP adapter for retrying failed requests that have returned a status code
     indicating a temporary error.

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -80,7 +80,7 @@ def _mount_retry(session, total_retries, backoff_factor=2):
     where {retry number} = 1, 2, 3, ..., total_retries
 
     With a backoff_factor of 5, the total sleep seconds between executions will be:
-    [0, 0+10, 0+10+20, 0+10+20+40, ...]
+    [0, 10, 20, 40, ...] (always 0 seconds before the first retry)
 
     Parameters
     ----------
@@ -110,7 +110,7 @@ def _retry_adapter(total_retries, backoff_factor=2):
     where {retry number} = 1, 2, 3, ..., total_retries
 
     With a backoff_factor of 5, the total sleep seconds between executions will be:
-    [0, 0+10, 0+10+20, 0+10+20+40, ...]
+    [0, 10, 20, 40, ...] (always 0 seconds before the first retry)
 
     Parameters
     ----------
@@ -172,7 +172,7 @@ def _eula_error_message(body: str) -> str:
 
 
 @lru_cache(maxsize=128)
-def _valid(oauth_host: str, oauth_client_id: str, access_token: str, max_download_retries: int) -> bool:
+def _valid(oauth_host: str, oauth_client_id: str, access_token: str, total_retries: int) -> bool:
     """
     Validates the user access token with Earthdata Login.
 
@@ -189,7 +189,7 @@ def _valid(oauth_host: str, oauth_client_id: str, access_token: str, max_downloa
     Boolean indicating a valid or invalid user access token
     """
     url = f'{oauth_host}/oauth/tokens/user?token={access_token}&client_id={oauth_client_id}'
-    with _mount_retry(requests.Session(), max_download_retries) as session:
+    with _mount_retry(requests.Session(), total_retries) as session:
         response = session.post(url, timeout=TIMEOUT)
 
         if response.ok:

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -457,8 +457,8 @@ def download(config, url: str, access_token: str, data, destination_file,
         raise ServerException(f'{msg} due to an unexpected data server error.')
 
     if response.status_code in RETRY_ERROR_CODES:
-        msg = f'Download of {url} failed due to a transient error \
-         (HTTP {response.status_code}) after multiple retry attempts.'
+        msg = f'Download of {url} failed due to a transient error ' +\
+         f'(HTTP {response.status_code}) after multiple retry attempts.'
         _log_retry_history(logger, response)
         logger.info(msg)
         raise TransientException(msg)

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -457,7 +457,8 @@ def download(config, url: str, access_token: str, data, destination_file,
         raise ServerException(f'{msg} due to an unexpected data server error.')
 
     if response.status_code in RETRY_ERROR_CODES:
-        msg = f'Download failed due to a transient error (HTTP {response.status_code}) after multiple retry attempts'
+        msg = f'Download of {url} failed due to a transient error \
+         (HTTP {response.status_code}) after multiple retry attempts.'
         _log_retry_history(logger, response)
         logger.info(msg)
         raise TransientException(msg)

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -77,6 +77,9 @@ def localhost_url(url, local_hostname):
 def _mount_retry(session, total_retries=DEFAULT_TOTAL_RETRIES, backoff_factor=0.2):
     """Mount a retry adapter to a requests session.
 
+    With a backoff_factor of 5, the total sleep seconds between executions will be:
+    [0, 0+10, 0+10+20, 0+10+20+40, ...]
+
     Parameters
     ----------
     session : requests.Session

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -88,7 +88,7 @@ def _mount_retry(session, total_retries, backoff_factor=2):
     backoff_factor: float
         Factor used to determine backoff/sleep time between executions:
         backoff = {backoff factor} * (2 ** ({retry number} - 1))
-        where {retry number} = 1, 2, 3...
+        where {retry number} = 1, 2, 3, ..., total_retries
 
     Returns
     -------
@@ -115,7 +115,7 @@ def _retry_adapter(total_retries, backoff_factor=2):
     backoff_factor: float
         Factor used to determine backoff/sleep time between executions:
         backoff = {backoff factor} * (2 ** ({retry number} - 1))
-        where {retry number} = 1, 2, 3...
+        where {retry number} = 1, 2, 3, ..., total_retries
 
     Returns
     -------

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -37,7 +37,7 @@ TIMEOUT = 60
 # Error codes for which the retry adapter will retry failed requests.
 # Only requests sessions with a mounted retry adapter will exhibit retry behavior.
 RETRY_ERROR_CODES = (408, 502, 503, 504)
-DEFAULT_TOTAL_RETRIES = 10 # per requests session
+DEFAULT_TOTAL_RETRIES = 10  # per requests session
 
 
 def is_http(url: str) -> bool:

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -74,7 +74,10 @@ def localhost_url(url, local_hostname):
 
 
 def _mount_retry(session, total_retries, backoff_factor=2):
-    """Mount a retry adapter to a requests session.
+    """Mount a retry adapter (with exponential backoff) to a requests session.
+
+    backoff = {backoff factor} * (2 ** ({retry number} - 1))
+    where {retry number} = 1, 2, 3, ..., total_retries
 
     With a backoff_factor of 5, the total sleep seconds between executions will be:
     [0, 0+10, 0+10+20, 0+10+20+40, ...]
@@ -86,9 +89,7 @@ def _mount_retry(session, total_retries, backoff_factor=2):
     total_retries: int
         Upper limit on the number of times to retry the request
     backoff_factor: float
-        Factor used to determine backoff/sleep time between executions:
-        backoff = {backoff factor} * (2 ** ({retry number} - 1))
-        where {retry number} = 1, 2, 3, ..., total_retries
+        Factor used to determine backoff/sleep time between executions
 
     Returns
     -------
@@ -102,8 +103,11 @@ def _mount_retry(session, total_retries, backoff_factor=2):
 
 def _retry_adapter(total_retries, backoff_factor=2):
     """
-    HTTP adapter for retrying failed requests that have returned a status code
+    HTTP adapter for retrying (with exponential backoff) failed requests that have returned a status code
     indicating a temporary error.
+
+    backoff = {backoff factor} * (2 ** ({retry number} - 1))
+    where {retry number} = 1, 2, 3, ..., total_retries
 
     With a backoff_factor of 5, the total sleep seconds between executions will be:
     [0, 0+10, 0+10+20, 0+10+20+40, ...]
@@ -113,9 +117,7 @@ def _retry_adapter(total_retries, backoff_factor=2):
     total_retries: int
         Upper limit on the number of times to retry the request
     backoff_factor: float
-        Factor used to determine backoff/sleep time between executions:
-        backoff = {backoff factor} * (2 ** ({retry number} - 1))
-        where {retry number} = 1, 2, 3, ..., total_retries
+        Factor used to determine backoff/sleep time between executions
 
     Returns
     -------

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -74,14 +74,9 @@ def localhost_url(url, local_hostname):
 
 
 def _mount_retry(session, total_retries, backoff_factor=2):
-    """Instantiates a retry adapter (with exponential backoff) and mounts it to the requests session.
-
-    backoff = {backoff factor} * (2 ** ({retry number} - 1))
-    where {retry number} = 1, 2, 3, ..., total_retries
-
-    With a backoff_factor of 5, the total sleep seconds between executions will be
-    [0, 10, 20, 40, ...]. There is always 0 seconds before the first retry.
-    120 seconds is the maximum backoff.
+    """
+    Instantiates a retry adapter (with exponential backoff) and mounts it to the requests session.
+    See _retry_adapter function for backoff algo details.
 
     Parameters
     ----------

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -20,7 +20,7 @@ import re
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 from harmony.earthdata import EarthdataAuth, EarthdataSession
 from harmony.exceptions import ForbiddenException
@@ -119,7 +119,7 @@ def _retry_adapter(total_retries=DEFAULT_TOTAL_RETRIES, backoff_factor=0.2):
                 status_forcelist=RETRY_ERROR_CODES,
                 raise_on_redirect=False,
                 raise_on_status=False,
-                allowed_methods=False)
+                method_whitelist=False)
     return HTTPAdapter(max_retries=retry)
 
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -91,6 +91,8 @@ def _mount_retry(session, total_retries, backoff_factor=2):
     -------
     The requests.Session
     """
+    if total_retries < 1:
+        return session
     adapter = _retry_adapter(total_retries, backoff_factor)
     session.mount('http://', adapter)
     session.mount('https://', adapter)
@@ -126,7 +128,7 @@ def _retry_adapter(total_retries, backoff_factor=2):
                 status_forcelist=RETRY_ERROR_CODES,
                 raise_on_redirect=False,
                 raise_on_status=False,
-                method_whitelist=False)
+                allowed_methods=False)
     return HTTPAdapter(max_retries=retry)
 
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -34,9 +34,9 @@ from harmony.logging import build_logger
 # https://2.python-requests.org/en/master/user/quickstart/#timeouts
 TIMEOUT = 60
 
+# Error codes for which we should retry failed requests
 RETRY_ERROR_CODES = (408, 502, 503, 504)
-
-DEFAULT_TOTAL_RETRIES=10
+DEFAULT_TOTAL_RETRIES = 10
 
 
 def is_http(url: str) -> bool:
@@ -74,12 +74,29 @@ def localhost_url(url, local_hostname):
 
 
 def retryAdapter(total_retries=DEFAULT_TOTAL_RETRIES, backoff_factor=0.2):
-    retry = Retry(total=total_retries, 
-        backoff_factor=backoff_factor,
-        status_forcelist=RETRY_ERROR_CODES,
-        raise_on_redirect=False,
-        raise_on_status=False,
-        allowed_methods=False)
+    """
+    HTTP adapter for retrying failed requests that have returned a status code
+    indicating a temporary error.
+
+    Parameters
+    ----------
+    total_retries: int
+        Upper limit on the number of times to retry the request
+    backoff_factor: float
+        Factor used to determine backoff/sleep time between executions:
+        backoff = {backoff factor} * (2 ** ({number of total retries} - 1))
+
+    Returns
+    -------
+    The urllib3 retry adapter
+    """
+    retry = Retry(
+                total=total_retries,
+                backoff_factor=backoff_factor,
+                status_forcelist=RETRY_ERROR_CODES,
+                raise_on_redirect=False,
+                raise_on_status=False,
+                allowed_methods=False)
     return HTTPAdapter(max_retries=retry)
 
 

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -79,8 +79,9 @@ def _mount_retry(session, total_retries, backoff_factor=2):
     backoff = {backoff factor} * (2 ** ({retry number} - 1))
     where {retry number} = 1, 2, 3, ..., total_retries
 
-    With a backoff_factor of 5, the total sleep seconds between executions will be:
-    [0, 10, 20, 40, ...] (always 0 seconds before the first retry)
+    With a backoff_factor of 5, the total sleep seconds between executions will be
+    [0, 10, 20, 40, ...]. There is always 0 seconds before the first retry.
+    120 seconds is the maximum backoff.
 
     Parameters
     ----------
@@ -109,8 +110,9 @@ def _retry_adapter(total_retries, backoff_factor=2):
     backoff = {backoff factor} * (2 ** ({retry number} - 1))
     where {retry number} = 1, 2, 3, ..., total_retries
 
-    With a backoff_factor of 5, the total sleep seconds between executions will be:
-    [0, 10, 20, 40, ...] (always 0 seconds before the first retry)
+    With a backoff_factor of 5, the total sleep seconds between executions will be
+    [0, 10, 20, 40, ...]. There is always 0 seconds before the first retry.
+    120 seconds is the maximum backoff.
 
     Parameters
     ----------

--- a/harmony/util.py
+++ b/harmony/util.py
@@ -165,7 +165,7 @@ def config(validate=True):
         value = environ.get(name)
         return str.lower(value) == 'true' if value is not None else default
 
-    def int_envvar(name: str, default: bool) -> int:
+    def int_envvar(name: str, default: int) -> int:
         value = environ.get(name)
         return int(value) if value is not None else default
 

--- a/harmony/util.py
+++ b/harmony/util.py
@@ -164,7 +164,7 @@ def config(validate=True):
     def bool_envvar(name: str, default: bool) -> bool:
         value = environ.get(name)
         return str.lower(value) == 'true' if value is not None else default
-    
+
     def int_envvar(name: str, default: bool) -> int:
         value = environ.get(name)
         return int(value) if value is not None else default

--- a/harmony/util.py
+++ b/harmony/util.py
@@ -18,7 +18,7 @@ Required when staging to S3 and not using the Harmony-provided stagingLocation p
     STAGING_PATH: The base path under which staged files should be placed
 
 Required when using HTTPS, allowing Earthdata Login auth:
-    OAUTH_HOST:     The Earthdata Login (EDL) environment to connect to
+    OAUTH_HOST:         The Earthdata Login (EDL) environment to connect to
     OAUTH_CLIENT_ID:    The EDL application client id used to acquire an EDL shared access token
     OAUTH_UID:          The EDL application UID used to acquire an EDL shared access token
     OAUTH_PASSWORD:     The EDL application password used to acquire an EDL shared access token
@@ -42,11 +42,12 @@ Optional when reading from or staging to S3:
     BACKEND_HOST:    The hostname of the Harmony backend. Deprecated / unused by this package.
 
 Optional:
-    APP_NAME:          A name for the service that will appear in log entries.
-    ENV:               The application environment. One of: dev, test. Used for local development.
-    TEXT_LOGGER:       Whether to log in plaintext or JSON. Default: True (plaintext).
-    HEALTH_CHECK_PATH: The filesystem path that should be `touch`ed to indicate the service is
-                       alive.
+    APP_NAME:             A name for the service that will appear in log entries.
+    ENV:                  The application environment. One of: dev, test. Used for local development.
+    TEXT_LOGGER:          Whether to log in plaintext or JSON. Default: True (plaintext).
+    HEALTH_CHECK_PATH:    The filesystem path that should be `touch`ed to indicate the service is
+                          alive.
+    MAX_DOWNLOAD_RETRIES: Number of times to retry failed HTTP calls via the http module.
 """
 
 from base64 import b64decode
@@ -97,7 +98,8 @@ Config = namedtuple(
         'text_logger',
         'health_check_path',
         'shared_secret_key',
-        'user_agent'
+        'user_agent',
+        'max_download_retries'
     ])
 
 
@@ -112,7 +114,8 @@ def _validated_config(config):
         'oauth_password',
         'oauth_redirect_uri',
         'staging_path',
-        'staging_bucket'
+        'staging_bucket',
+        'max_download_retries'
     ]
 
     unset = [var.upper() for var in required if getattr(config, var) is None]
@@ -161,6 +164,10 @@ def config(validate=True):
     def bool_envvar(name: str, default: bool) -> bool:
         value = environ.get(name)
         return str.lower(value) == 'true' if value is not None else default
+    
+    def int_envvar(name: str, default: bool) -> int:
+        value = environ.get(name)
+        return int(value) if value is not None else default
 
     oauth_redirect_uri = str_envvar('OAUTH_REDIRECT_URI', None)
     if oauth_redirect_uri is not None:
@@ -188,7 +195,8 @@ def config(validate=True):
         text_logger=bool_envvar('TEXT_LOGGER', False),
         health_check_path=str_envvar('HEALTH_CHECK_PATH', '/tmp/health.txt'),
         shared_secret_key=str_envvar('SHARED_SECRET_KEY', DEFAULT_SHARED_SECRET_KEY),
-        user_agent=str_envvar('USER_AGENT', 'harmony (unknown version)')
+        user_agent=str_envvar('USER_AGENT', 'harmony (unknown version)'),
+        max_download_retries=int_envvar('MAX_DOWNLOAD_RETRIES', 0)
     )
 
     if validate:

--- a/harmony/util.py
+++ b/harmony/util.py
@@ -47,7 +47,7 @@ Optional:
     TEXT_LOGGER:          Whether to log in plaintext or JSON. Default: True (plaintext).
     HEALTH_CHECK_PATH:    The filesystem path that should be `touch`ed to indicate the service is
                           alive.
-    MAX_DOWNLOAD_RETRIES: Number of times to retry failed HTTP calls via the http module.
+    MAX_DOWNLOAD_RETRIES: Number of times to retry HTTP download calls that fail due to transient errors.
 """
 
 from base64 import b64decode

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pynacl ~= 1.4
 pystac ~= 0.5.3
 python-json-logger ~= 2.0.1
 requests ~= 2.24
+urllib3 ~= 1.26.9

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -541,8 +541,7 @@ def test_retries_on_temporary_errors_edl_auth(
     destination_file = mocker.Mock()
     cfg = config_fixture()
 
-    user_agent = 'test-agent/0.0.0'
-    response = download(cfg, resource_server_granule_url, access_token, None, destination_file, user_agent=user_agent)
+    response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
     
     assert response.status_code == 200
     assert rsp1.call_count == 1
@@ -567,8 +566,7 @@ def test_retries_on_temporary_errors_basic_auth(
     client_id = faker.password(length=22, special_chars=False)
     cfg = config_fixture(oauth_client_id=client_id, fallback_authn_enabled=True)
 
-    user_agent = 'test-agent/0.0.0'
-    response = download(cfg, resource_server_granule_url, access_token, None, destination_file, user_agent=user_agent)
+    response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
     
     assert response.status_code == 200
     assert rsp1.call_count == 1
@@ -591,8 +589,7 @@ def test_retries_on_temporary_errors_until_limit(
     destination_file = mocker.Mock()
     cfg = config_fixture()
 
-    user_agent = 'test-agent/0.0.0'
     with pytest.raises(Exception) as e:
-        download(cfg, resource_server_granule_url, access_token, None, destination_file, user_agent=user_agent)
+        download(cfg, resource_server_granule_url, access_token, None, destination_file)
         assert e.type == Exception
         assert f'Download failed with status {error_code} after multiple retry attempts' in e.value.message

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -592,4 +592,4 @@ def test_retries_on_temporary_errors_until_limit(
     with pytest.raises(Exception) as e:
         download(cfg, resource_server_granule_url, access_token, None, destination_file)
         assert e.type == Exception
-        assert f'Download failed with status {error_code} after multiple retry attempts' in e.value.message
+        assert f'failed due to a transient error (HTTP {error_code}) after multiple retry attempts' in e.value.message

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -86,7 +86,7 @@ def test_download_follows_redirect_to_edl_and_adds_auth_headers(
         edl_redirect_url,
         getsize_patched):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     responses.add(
         responses.GET,
         resource_server_granule_url,
@@ -133,7 +133,7 @@ def test_download_follows_redirect_to_resource_server_with_code(
         headers=[('Location', resource_server_redirect_url)]
     )
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     responses.add(
         responses.GET,
         resource_server_redirect_url,
@@ -161,7 +161,7 @@ def test_resource_server_redirects_to_granule_url(
         resource_server_granule_url,
         getsize_patched):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     responses.add(
         responses.GET,
         resource_server_redirect_url,
@@ -273,7 +273,7 @@ def test_when_given_a_url_and_data_it_downloads_with_query_parameters(
         resource_server_granule_url,
         getsize_patched):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     responses.add(
         responses.POST,
         resource_server_granule_url,
@@ -299,7 +299,7 @@ def test_when_authn_succeeds_it_writes_to_provided_file(
         response_body_from_granule_url,
         getsize_patched):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     responses.add(
         responses.GET,
         resource_server_granule_url,
@@ -325,7 +325,7 @@ def test_when_given_an_access_token_and_error_occurs_it_falls_back_to_basic_auth
         response_body_from_granule_url,
         getsize_patched):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     client_id = faker.password(length=22, special_chars=False)
     access_token = faker.password(length=42, special_chars=False)
     cfg = config_fixture(oauth_client_id=client_id, fallback_authn_enabled=True)
@@ -359,7 +359,7 @@ def test_when_given_an_access_token_and_error_occurs_it_does_not_fall_back_to_ba
         faker,
         resource_server_granule_url):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     client_id = faker.password(length=22, special_chars=False)
     access_token = faker.password(length=42, special_chars=False)
     cfg = config_fixture(oauth_client_id=client_id, fallback_authn_enabled=False)
@@ -413,7 +413,7 @@ def test_download_unknown_error_exception_if_all_else_fails(
         faker,
         resource_server_granule_url):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     client_id = faker.password(length=22, special_chars=False)
     access_token = faker.password(length=42, special_chars=False)
     cfg = config_fixture(oauth_client_id=client_id, fallback_authn_enabled=False)
@@ -485,7 +485,7 @@ def test_user_agent_is_passed_to_request_headers_when_using_edl_auth(
         resource_server_granule_url,
         getsize_patched):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     responses.add(
         responses.GET,
         resource_server_granule_url,
@@ -508,7 +508,7 @@ def test_user_agent_is_passed_to_request_headers_when_using_edl_auth_and_post_pa
         resource_server_granule_url,
         getsize_patched):
 
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     responses.add(
         responses.POST,
         resource_server_granule_url,
@@ -533,13 +533,13 @@ def test_retries_on_temporary_errors_edl_auth(
         resource_server_granule_url,
         getsize_patched,
         error_code):
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     rsp1 = responses.get(resource_server_granule_url, body="Error", status=error_code)
     rsp2 = responses.get(resource_server_granule_url, body="Error", status=error_code)
     rsp3 = responses.get(resource_server_granule_url, body="OK", status=200)
 
     destination_file = mocker.Mock()
-    cfg = config_fixture()
+    cfg = config_fixture(max_download_retries=5)
 
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
     
@@ -564,7 +564,7 @@ def test_retries_on_temporary_errors_basic_auth(
 
     destination_file = mocker.Mock()
     client_id = faker.password(length=22, special_chars=False)
-    cfg = config_fixture(oauth_client_id=client_id, fallback_authn_enabled=True)
+    cfg = config_fixture(oauth_client_id=client_id, fallback_authn_enabled=True, max_download_retries=5)
 
     response = download(cfg, resource_server_granule_url, access_token, None, destination_file)
     
@@ -582,12 +582,12 @@ def test_retries_on_temporary_errors_until_limit(
         resource_server_granule_url,
         getsize_patched,
         error_code):
-    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c: True)
+    monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
     for i in range(0, DEFAULT_TOTAL_RETRIES):
         responses.get(resource_server_granule_url, body="Error", status=error_code)
 
     destination_file = mocker.Mock()
-    cfg = config_fixture()
+    cfg = config_fixture(max_download_retries=5)
 
     with pytest.raises(Exception) as e:
         download(cfg, resource_server_granule_url, access_token, None, destination_file)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -3,7 +3,7 @@ import responses
 import os
 
 import harmony.http
-from harmony.http import (download, is_http, localhost_url, RETRY_ERROR_CODES, DEFAULT_TOTAL_RETRIES)
+from harmony.http import (download, is_http, localhost_url, RETRY_ERROR_CODES)
 from tests.util import config_fixture
 
 EDL_URL = 'https://uat.urs.earthdata.nasa.gov'
@@ -583,7 +583,7 @@ def test_retries_on_temporary_errors_until_limit(
         getsize_patched,
         error_code):
     monkeypatch.setattr(harmony.http, '_valid', lambda a, b, c, d: True)
-    for i in range(0, DEFAULT_TOTAL_RETRIES):
+    for i in range(0, 5):
         responses.get(resource_server_granule_url, body="Error", status=error_code)
 
     destination_file = mocker.Mock()

--- a/tests/test_util_download.py
+++ b/tests/test_util_download.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 import responses
 
-from harmony.exceptions import ForbiddenException
+from harmony.exceptions import ForbiddenException, ServerException
 from harmony import util
 from tests.util import config_fixture
 
@@ -178,5 +178,5 @@ def test_when_the_url_returns_a_500_it_does_not_raise_a_forbidden_exception_and_
     with mock.patch('builtins.open', mock.mock_open()):
         with pytest.raises(Exception) as e:
             util.download(url, '/tmp', access_token=access_token, cfg=config)
-        assert e.type != ForbiddenException and e.type == Exception
+        assert e.type != ForbiddenException and e.type == ServerException
         assert len(responses.calls) == 2

--- a/tests/util.py
+++ b/tests/util.py
@@ -78,7 +78,8 @@ def config_fixture(fallback_authn_enabled=False,
                    oauth_client_id=None,
                    user_agent=None,
                    app_name=None,
-                   text_logger=False):
+                   text_logger=False,
+                   max_download_retries=5):
     c = util.config(validate=False)
     return util.Config(
         # Override
@@ -91,6 +92,7 @@ def config_fixture(fallback_authn_enabled=False,
         oauth_client_id=oauth_client_id,
         app_name=app_name,
         text_logger=text_logger,
+        max_download_retries=max_download_retries,
         # Default
         env=c.env,
         oauth_host=c.oauth_host,


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1125

## Description
Automatically retries temporary request failures using https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html. 

Here is what the end result should look like on the Harmony side. (Note that I I also tweaked the way 500 download errors are handled as well by giving them a custom exception class so that we don't see the "unknown error" on the Harmony job.)

<img width="1479" alt="Screen Shot 2022-06-02 at 10 05 54 AM" src="https://user-images.githubusercontent.com/34752045/171649043-933b0d5f-5743-45c7-9eba-507c1a76826d.png">

<img width="1306" alt="Screen Shot 2022-06-02 at 10 05 35 AM" src="https://user-images.githubusercontent.com/34752045/171649071-58f11353-6bac-490d-90eb-1724dd8c7772.png">


## Local Test Steps
Checkout harmony-1125 in this repo and in the  Harmony repo. In harmony-service-lib-py activate your virtual environment and run `make install` to ensure the right version of responses is installed before running `make test`.
### Testing with Harmony
1. In harmony-service-lib-py in http.py at the top of the download function set `url='https://httpbin.org/status/502'`.
2. Build a service using your local copy of harmony-service-lib-py (e.g. `make build-image LOCAL_SVCLIB_DIR=../harmony-service-lib-py` in harmony-service-example)
3. In your env file for the harmony repo set `MAX_DOWNLOAD_RETRIES=4` or whatever value you want. 
4. Restart your harmony services in k8s and make a request. The retry history should be logged _after_ the final download failure.

### Testing harmony-service-lib-py only (tedious)
1. Navigate to harmony-service-lib-py root dir.
2. Make sure you have an .env file there with something like:
```
# this is the thing we're testing
MAX_DOWNLOAD_RETRIES=3

OAUTH_CLIENT_ID=123
OAUTH_UID=local_harmony
OAUTH_PASSWORD=abc
OAUTH_REDIRECT_URI=http://localhost:3000/oauth2/redirect
STAGING_PATH=public/harmony/service-example
STAGING_BUCKET=local-staging-bucket
FALLBACK_AUTHN_ENABLED=true
EDL_USERNAME=a
EDL_PASSWORD=b
```
3. Activate your virtual environment and pip install dotenv.
4. In util.py comment out the `download` function and `from harmony import http`. (This will prevent a circular ref later on.)
5. Add the following to the bottom of http.py:
```
import dotenv
from harmony.util import config

print(dotenv.load_dotenv('.env'))
download(config(), 'https://httpbin.org/status/502', None, None, '/file',
             user_agent=None, stream=True, buffer_size=1024*1024*16)
```
6a. (optional) In _download_with_fallback_authn, modify/add this code (which prints the retried requests):
```
resp = session.get(url, headers=headers, timeout=TIMEOUT, **kwargs_download_agent)
for r in resp.raw.retries.history:
    print(r)
return resp
```
6b. (optional) In order to log some of the retry logic from the urllib3 Retry class, navigate to `venv/lib/python3.9/site-packages/urllib3/util/retry.py` (your path may differ). The relevant functions you may want to print things in are `get_backoff_time` and `_sleep_backoff`.
7. From harmony-service-lib-py root dir, run `python -m harmony.http`

With this setup you'll be using the default backoff factor of 2, but that can be modified as well. Similar code can be added to trigger the other http requests in http.py, but it will ultimately produce the same outcome.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing