### PR TITLE
HARMONY-1125: Work around twine upload issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,11 @@ publish: build
 clean:
 	rm -rf build dist *.egg-info || true
 
+# HARMONY-1188 - revert this command to:
+# pip install -e .[dev]
 install:
-	pip install -e .[dev]
+	pip install -r dev-requirements.txt
+	pip install -r requirements.txt
 
 lint:
 	flake8 harmony

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ pytest ~= 6.2
 pytest-cov ~=2.11
 pytest-mock ~=3.5
 python-language-server ~= 0.35
-# change this to an official release once the code in this commit is released (https://github.com/getsentry/responses/releases)
+# HARMONY-1188 - change this to an official release once the code in this commit is released (https://github.com/getsentry/responses/releases)
 responses @ git+https://github.com/getsentry/responses.git@bdc5eff7169a6fba730f2f8427d5ec5a817b1ad5
 safety ~= 1.8
 pycodestyle ~= 2.7.0

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,10 @@ setup(
     },
     zip_safe=False,
     install_requires=DEPENDENCIES,
-    extras_require={
-        'dev': DEV_DEPENDENCIES
-    },
+    # HARMONY-1188 - uncomment this
+    # extras_require={
+    #     'dev': DEV_DEPENDENCIES
+    # },
     test_suite="tests",
     python_requires=">=3.7",
     # license and classifier list:


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1125

## Description
Works around this issue https://github.com/pypa/twine/issues/726, https://peps.python.org/pep-0440/#direct-references:
> Public index servers SHOULD NOT allow the use of direct references in uploaded distributions. Direct references are 
> intended as a tool for software integrators rather than publishers.

https://bugs.earthdata.nasa.gov/browse/HARMONY-1188 was created to revert these changes once responses has a new release and the workaround is no longer needed.

## Local Test Steps
With your virtual env activated:
run `make install`
run `make test`
The error https://github.com/nasa/harmony-service-lib-py/runs/6757666515?check_suite_focus=true#step:4:59 is not reproducible locally but the relevant failing command is:
`python -m twine upload --username "__token__" -*** --repository-url "https://upload.pypi.org/legacy/" dist/*`