### PR TITLE
HARMONY-1195: Retry all file download error conditions except for authorization errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,8 @@ lint:
 test:
 	pytest --cov=harmony tests
 
+test-no-warnings:
+	pytest --disable-warnings --cov=harmony tests
+
 cve-check:
 	safety check

--- a/harmony/exceptions.py
+++ b/harmony/exceptions.py
@@ -33,4 +33,3 @@ class ServerException(HarmonyException):
 
     def __init__(self, message=None):
         super().__init__(message, 'Server')
-

--- a/harmony/exceptions.py
+++ b/harmony/exceptions.py
@@ -34,9 +34,3 @@ class ServerException(HarmonyException):
     def __init__(self, message=None):
         super().__init__(message, 'Server')
 
-
-class TransientException(HarmonyException):
-    """Class for throwing an exception indicating the download failed due to a transient HTTP error (e.g. 502) """
-
-    def __init__(self, message=None):
-        super().__init__(message, 'Transient')

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -36,7 +36,7 @@ TIMEOUT = 60
 
 # Error codes for which the retry adapter will retry failed requests.
 # Only requests sessions with a mounted retry adapter will exhibit retry behavior.
-RETRY_ERROR_CODES = (408, 502, 503, 504)
+RETRY_ERROR_CODES = list(range(400, 600)) # Any http status code should be retried
 
 
 def is_http(url: str) -> bool:
@@ -346,7 +346,7 @@ def _log_download_performance(logger, url, duration_ms, file_size):
         "path": url_path,
         "size": file_size
     }
-    logger.info('timing.download.end', extra=extra_fields)
+    logger.info('CDD - your code - timing.download.end', extra=extra_fields)
 
 
 def download(config, url: str, access_token: str, data, destination_file,
@@ -404,7 +404,7 @@ def download(config, url: str, access_token: str, data, destination_file,
     response = None
     logger = build_logger(config)
     start_time = datetime.datetime.now()
-    logger.info(f'timing.download.start {url}')
+    logger.info(f'CDD updated code - timing.download.start {url}')
 
     if (not stream) and buffer_size:
         logger.warn(
@@ -462,5 +462,5 @@ def download(config, url: str, access_token: str, data, destination_file,
         logger.info(msg)
         raise TransientException(msg)
 
-    logger.info(f'Unable to download (unknown error) due to: {response.content}')
+    logger.info(f'Unable to download (unknown error) due to status code: {response.status_code} and content {response.content}')
     raise Exception('Unable to download: unknown error.')


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1195

## Description
We've seen several different classes of errors including 400s and 500s where we want to retry the failure because it may succeed on a retry. The only cases where we definitely do not want to retry the same request are 401 and 403 errors.

We were seeing an issue with the way we were using the urllib Retry library to automatically retry HTTP errors because we'd see intermittent failures 3 redirects in verifying an authorization code with EDL. When that would fail we'd retry that specific redirect instead of the original URL, which was a problem because the EDL authorization codes are one time use only so that retry would always fail.

This changes the retries to happen a level up outside the HTTP urllib library, which allows those requests to succeed on a retry.

I also removed a superfluous check that was calling EDL to verify a token. The token is going to be verified by the download site and has already been verified once by the harmony frontend. If the token ends up being invalid the download site will return an error, so there's no change in behavior by removing this check.

## Local Test Steps
You could try to create some download error scenarios or manually modify the code so that it fails (maybe changing the download URL to something invalid) and then build a service to use your local harmony service library. Verify that it retries the expected number of times for your MAX_DOWNLOAD_RETRIES before failing.

I've been testing in my own sandbox environment and seen a few retries logged and then on subsequent requests they succeed.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)