### PR TITLE
HARMONY-1191: Add short name and version id to message

### DIFF
--- a/example/example_message.json
+++ b/example/example_message.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "../../harmony/app/schemas/data-operation/0.16.0/data-operation-v0.16.0.json",
-  "version": "0.16.0",
+  "$schema": "../../harmony/app/schemas/data-operation/0.17.0/data-operation-v0.17.0.json",
+  "version": "0.17.0",
   "callback": "http://localhost/some-path",
   "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
   "user": "jdoe",
@@ -10,6 +10,8 @@
   "accessToken": "ABCD1234567890",
   "sources": [{
       "collection": "C1233800302-EEDTEST",
+      "shortName": "harmony_example",
+      "versionId": "1",
       "variables": [{
           "id": "V0001-EXAMPLE",
           "name": "ExampleVar",

--- a/harmony/message.py
+++ b/harmony/message.py
@@ -106,6 +106,10 @@ class Source(JsonObject):
     ----------
     collection : string
         The id of the collection the data source's variables and granules are in
+    shortName : string
+        The unique short name of the collection as returned by the CMR
+    versionId : string
+        The version id of the collection as returned by the CMR
     variables : list
         A list of Variable objects for the variables which should be transformed
     coordinateVariables: list
@@ -125,7 +129,7 @@ class Source(JsonObject):
             The Harmony message "sources" item to deserialize
         """
         super().__init__(message_data,
-                         properties=['collection'],
+                         properties=['collection', 'shortName', 'versionId'],
                          list_properties={
                              'variables': Variable,
                              'coordinateVariables': Variable,

--- a/tests/example_messages.py
+++ b/tests/example_messages.py
@@ -1,7 +1,7 @@
 minimal_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.16.0/data-operation-v0.16.0.json",
-        "version": "0.16.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.17.0/data-operation-v0.17.0.json",
+        "version": "0.17.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -19,8 +19,8 @@ minimal_message = """
 
 minimal_source_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.16.0/data-operation-v0.16.0.json",
-        "version": "0.16.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.17.0/data-operation-v0.17.0.json",
+        "version": "0.17.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -30,6 +30,8 @@ minimal_source_message = """
         "sources": [
             {
             "collection": "C0001-EXAMPLE",
+            "shortName": "example_1_data",
+            "versionId": "1",
             "variables": [],
             "coordinateVariables": [],
             "granules": []
@@ -44,8 +46,8 @@ minimal_source_message = """
 
 full_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.16.0/data-operation-v0.16.0.json",
-        "version": "0.16.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.17.0/data-operation-v0.17.0.json",
+        "version": "0.17.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -55,6 +57,8 @@ full_message = """
         "accessToken": "ABCD1234567890",
         "sources": [{
             "collection": "C0001-EXAMPLE",
+            "shortName": "example_1_data",
+            "versionId": "1",
             "variables": [{
                 "id": "V0001-EXAMPLE",
                 "name": "ExampleVar1",
@@ -101,6 +105,8 @@ full_message = """
                 }
             ]}, {
             "collection": "C0002-EXAMPLE",
+            "shortName": "example_2_data",
+            "versionId": "1",
             "variables": [
                 {
                 "id": "V0002-EXAMPLE",

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -13,7 +13,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_full_message_it_parses_it_into_objects(self):
         message = Message(full_message)
 
-        self.assertEqual(message.version, '0.16.0')
+        self.assertEqual(message.version, '0.17.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -23,6 +23,8 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.accessToken, 'ABCD1234567890')
         self.assertEqual(message.concatenate, True)
         self.assertEqual(message.sources[0].collection, 'C0001-EXAMPLE')
+        self.assertEqual(message.sources[0].shortName, 'example_1_data')
+        self.assertEqual(message.sources[0].versionId, '1')
         self.assertEqual(message.sources[0].variables[0].id, 'V0001-EXAMPLE')
         self.assertEqual(message.sources[0].variables[0].name, 'ExampleVar1')
         self.assertEqual(message.sources[0].variables[0].fullPath, 'example/path/ExampleVar1')
@@ -47,6 +49,8 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.sources[0].granules[1].temporal.end, '2004-04-04T04:04:04Z')
         self.assertEqual(message.sources[0].granules[1].bbox, [-5, -6, 7, 8])
         self.assertEqual(message.sources[1].collection, 'C0002-EXAMPLE')
+        self.assertEqual(message.sources[1].shortName, 'example_2_data')
+        self.assertEqual(message.sources[1].versionId, '1')
         self.assertEqual(message.sources[1].variables[0].fullPath, 'example/path/ExampleVar2')
         self.assertEqual(message.format.crs, 'CRS:84')
         self.assertEqual(message.format.srs.proj4, '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
@@ -79,7 +83,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_minimal_message_it_parses_it_into_objects(self):
         message = Message(minimal_message)
 
-        self.assertEqual(message.version, '0.16.0')
+        self.assertEqual(message.version, '0.17.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -99,11 +103,13 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_message_with_minimal_source_it_parses_it_into_objects(self):
         message = Message(minimal_source_message)
 
-        self.assertEqual(message.version, '0.16.0')
+        self.assertEqual(message.version, '0.17.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.user, 'jdoe')
         self.assertEqual(message.accessToken, 'ABCD1234567890')
         self.assertEqual(message.sources[0].collection, 'C0001-EXAMPLE')
+        self.assertEqual(message.sources[0].shortName, 'example_1_data')
+        self.assertEqual(message.sources[0].versionId, '1')
         self.assertEqual(message.sources[0].variables, [])
         self.assertEqual(message.sources[0].coordinateVariables, [])
         self.assertEqual(message.sources[0].granules, [])


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1191

## Description
This PR just updates the message object to handle the new fields (collection shortName, versionId) being passed to services from Harmony.

## Local Test Steps
Build a service (like harmony-service-example) using this branch of the service lib and test it out (http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=2) with Harmony branch 1191. Log the source.shortName and source.versionId in your service's `process_item` method.

```
        print(source)
        print(source.versionId)
        print(source.shortName)
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)