### PR TITLE
HARMONY-1247: Write the error file to s3 if metadata dir is s3

### DIFF
--- a/harmony/aws.py
+++ b/harmony/aws.py
@@ -46,7 +46,7 @@ def aws_parameters(use_localstack, localstack_host, region):
         }
 
 
-def write_s3(txt, url):
+def write_s3(url, txt):
     """
     Writes text to the given  s3 url.
 

--- a/harmony/aws.py
+++ b/harmony/aws.py
@@ -46,16 +46,16 @@ def aws_parameters(use_localstack, localstack_host, region):
         }
 
 
-def write_s3(txt, uri):
+def write_s3(txt, url):
     """
-    Writes text to the given  s3 uri.
+    Writes text to the given  s3 url.
 
     Parameters
     ----------
-    uri: The s3 file uri.
+    url: The s3 file url.
     txt: The file contents.
     """
-    parsed = urlparse(uri)
+    parsed = urlparse(url)
     config = util.config(validate=environ.get('ENV') != 'test')
     service_params = aws_parameters(
             config.use_localstack, config.localstack_host, config.aws_default_region)

--- a/harmony/aws.py
+++ b/harmony/aws.py
@@ -5,8 +5,11 @@ messages in SQS queues.
 This module relies on the harmony.util.config and its environment variables to be
 set for correct operation. See that module and the project README for details.
 """
+from urllib.parse import urlparse
+from os import environ
 import boto3
 from botocore.config import Config
+from harmony import util
 
 
 def is_s3(url: str) -> bool:
@@ -41,6 +44,25 @@ def aws_parameters(use_localstack, localstack_host, region):
         return {
             'region_name': region
         }
+
+
+def write_s3(txt, uri):
+    """
+    Writes text to the given  s3 uri.
+
+    Parameters
+    ----------
+    uri: The s3 file uri.
+    txt: The file contents.
+    """
+    parsed = urlparse(uri)
+    config = util.config(validate=environ.get('ENV') != 'test')
+    service_params = aws_parameters(
+            config.use_localstack, config.localstack_host, config.aws_default_region)
+    bucket = parsed.netloc
+    key = parsed.path[1:]
+    s3 = boto3.resource("s3", **service_params)
+    s3.Object(bucket, key).put(Body=txt)
 
 
 def _get_aws_client(config, service, user_agent=None):

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -147,7 +147,7 @@ def _write_error(metadata_dir, message, category='Unknown'):
     error_data = {'error': message, 'category': category}
     if is_s3(metadata_dir):
         json_str = json.dumps(error_data)
-        write_s3(json_str, f'{metadata_dir}error.json')
+        write_s3(f'{metadata_dir}error.json', json_str)
     else:
         with open(path.join(metadata_dir, 'error.json'), 'w') as file:
             json.dump(error_data, file)

--- a/harmony/s3_stac_io.py
+++ b/harmony/s3_stac_io.py
@@ -47,14 +47,8 @@ def write(uri, txt):
     uri: The STAC file uri.
     txt: The STAC contents.
     """
-    config = util.config(validate=environ.get('ENV') != 'test')
-    service_params = aws.aws_parameters(
-        config.use_localstack, config.localstack_host, config.aws_default_region)
     parsed = urlparse(uri)
     if parsed.scheme == 's3':
-        bucket = parsed.netloc
-        key = parsed.path[1:]
-        s3 = boto3.resource("s3", **service_params)
-        s3.Object(bucket, key).put(Body=txt)
+        aws.write_s3(txt, uri)
     else:
         STAC_IO.default_write_text_method(uri, txt)

--- a/harmony/s3_stac_io.py
+++ b/harmony/s3_stac_io.py
@@ -49,6 +49,6 @@ def write(uri, txt):
     """
     parsed = urlparse(uri)
     if parsed.scheme == 's3':
-        aws.write_s3(txt, uri)
+        aws.write_s3(uri, txt)
     else:
         STAC_IO.default_write_text_method(uri, txt)


### PR DESCRIPTION
## Jira Issue ID
harmony-1247

## Description
When we transitioned from S3 to EFS I forgot to also modify the service lib to write the error message JSON files to S3. This change rectifies that oversight.

## Local Test Steps
- check out this branch
- in transform.py proccess_item method of harmony-service-example add `raise HarmonyException('oh no')`
- `make build-image LOCAL_SVCLIB_DIR=../harmony-service-lib-py` in harmony-service-example
- restart services
- http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=2
- the job's error message should say 'oh no'

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)