### PR TITLE
Harmony 1204 - Fix service logging format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # necessary to pin this version to <5.0.0 for now
 # due to https://github.com/python/importlib_metadata/issues/406
-# which causes the GitHub action to fail running flake8 with pthon3.7
+# which causes the GitHub action to fail running flake8 with python3.7
 importlib-metadata==4.13.0
 autopep8 ~= 1.5
 debugpy ~= 1.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 # necessary to pin this version to <5.0.0 for now
 # due to https://github.com/python/importlib_metadata/issues/406
+# which causes the GitHub action to fail running flake8 with pthon3.7
 importlib-metadata==4.13.0
 autopep8 ~= 1.5
 debugpy ~= 1.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,6 @@
+# necessary to pin this version to <5.0.0 for now
+# due to https://github.com/python/importlib_metadata/issues/406
+importlib-metadata==4.13.0
 autopep8 ~= 1.5
 debugpy ~= 1.2
 Faker ~= 8.1.3

--- a/harmony/logging.py
+++ b/harmony/logging.py
@@ -78,20 +78,17 @@ def build_logger(config, name=None, stream=None):
     logger : Logging
         A logger for service output
     """
-    logger = logging.getLogger()
+    logger = logging.getLogger('harmony')
     syslog = logging.StreamHandler(stream)
     if config.text_logger:
         formatter = logging.Formatter("%(asctime)s [%(levelname)s] [%(name)s.%(funcName)s:%(lineno)d] %(message)s")
     else:
         formatter = HarmonyJsonFormatter()
         formatter.app_name = config.app_name
-    syslog.setFormatter(formatter)
+    syslog.setFormatter(RedactorFormatter(formatter))
     logger.addHandler(syslog)
     logger.setLevel(logging.INFO)
     logger.propagate = False
-    # wrap each handler in the redactor formatter
-    for handler in logging.root.handlers:
-        handler.setFormatter(RedactorFormatter(handler.formatter))
     return logger
 
 

--- a/harmony/logging.py
+++ b/harmony/logging.py
@@ -61,7 +61,7 @@ class RedactorFormatter(object):
 
 
 @lru_cache(maxsize=128)
-def build_logger(config, name=None, stream=None):
+def build_logger(config, name='harmony-service', stream=None):
     """
     Builds a logger with appropriate defaults for Harmony
     Parameters
@@ -78,7 +78,7 @@ def build_logger(config, name=None, stream=None):
     logger : Logging
         A logger for service output
     """
-    logger = logging.getLogger('harmony')
+    logger = logging.getLogger(name)
     syslog = logging.StreamHandler(stream)
     if config.text_logger:
         formatter = logging.Formatter("%(asctime)s [%(levelname)s] [%(name)s.%(funcName)s:%(lineno)d] %(message)s")


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1204

## Description
This fixes issues associated with service logging. Messages that should have shown up as JSON were showing up as text in Kibana, and were being duplicated.

This is because the root logger was always being used with 2 handlers (each of which can log the same message). The root logger already has a default handler attached to it and we were adding a subsequent custom handler. Therefore duplicate messages were being output as text+JSON (separated by /r/n) and were unable to be parsed as JSON.

(A logging handler doesn't always handle a log record if it is incompatible with its logic so sometimes only one of the handlers was being invoked (e.g. the custom JSON handler) and logs showed up just as expected, but this wasn't always the case.)

The least disruptive fix is to ensure that the root logger isn't used by always giving the logger that we retrieve a name `logging.getLogger(name)` (the same call without a name gives you the root logger instance). Non-root loggers don't have a default handler attached, so when we add our custom handler to it (the Harmony format handler) there is a total of one handler and therefore only one logged record.

----

In theory, the preexisting code: `logger.propagate = False` should have kept the root logger from being invoked, but that only comes into play if you're using a non-root logger (which we were not, since we were calling `logging.getLogger(name=None)`). 

An alternate solution would have been to keep using the root logger by setting `root_logger.handlers = []` and then adding our custom Harmony format handler to the root logger, but that would've been more complex and somewhat incompatible with the existing logic.

## Local Test Steps
Build harmony service example or another service with this branch of the service lib:
`(venv) vinverso@GSLA harmony-service-example % make build-image LOCAL_SVCLIB_DIR=../harmony-service-lib-py`. Then check the service logs, which should not have any duplicates and should have consistent formatting (only JSON or only text depending on the `TEXT_LOGGER` env variable for both the service and harmony).

I think we use TEXT_LOGGER=false in production, so that's what I would use in your Harmony env.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)