### PR TITLE
Harmony 784, 1188 - Dependency updates (github actions, responses, flake8, pycodestyle)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,4 +12,4 @@ python-language-server ~= 0.35
 # HARMONY-1188 - change this to an official release once the code in this commit is released (https://github.com/getsentry/responses/releases)
 responses @ git+https://github.com/getsentry/responses.git@bdc5eff7169a6fba730f2f8427d5ec5a817b1ad5
 safety ~= 1.8
-pycodestyle ~= 2.7.0
+pycodestyle ~= 2.9.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,7 @@
-# necessary to pin this version to <5.0.0 for now
-# due to https://github.com/python/importlib_metadata/issues/406
-# which causes the GitHub action to fail running flake8 with python3.7
-importlib-metadata==4.13.0
 autopep8 ~= 1.5
 debugpy ~= 1.2
 Faker ~= 8.1.3
-flake8 ~= 3.8
+flake8 ~= 5.0.4
 ipython ~= 7.17
 jedi ~= 0.17.2
 parameterized ~= 0.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,6 @@ pytest ~= 6.2
 pytest-cov ~=2.11
 pytest-mock ~=3.5
 python-language-server ~= 0.35
-# HARMONY-1188 - change this to an official release once the code in this commit is released (https://github.com/getsentry/responses/releases)
-responses @ git+https://github.com/getsentry/responses.git@bdc5eff7169a6fba730f2f8427d5ec5a817b1ad5
+responses ~=0.22.0
 safety ~= 1.8
 pycodestyle ~= 2.9.1


### PR DESCRIPTION
## Jira Issue ID
I made this branch harmony-784 so that it is linked to the similar dependency updates that I tacked onto https://github.com/nasa/harmony-py/pull/51/files, but I probably should have made this branch harmony-1188 ("Update harmony-service-lib-py responses dev dependency to an official release") as that is the ticket that is most related to this PR.

## Description
This just updates some pip and github action dev dependencies.

## Local Test Steps
make install
make lint
make test

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)