### PR TITLE
Harmony 1624 - Allow service implementations to output multiple STAC catalogs

### DIFF
--- a/harmony/adapter.py
+++ b/harmony/adapter.py
@@ -106,9 +106,10 @@ class BaseHarmonyAdapter(ABC):
 
         Returns
         -------
-        (harmony.Message, pystac.Catalog)
+        (harmony.Message, pystac.Catalog | list)
             A tuple of the Harmony message, with any processed fields marked as such and
-            a STAC catalog describing the output
+            in this implementation, a single STAC catalog describing the output.
+            (Services overriding this method may return a list of STAC catalogs if desired.)
         """
         # New-style processing using STAC
         if self.catalog:

--- a/harmony/adapter.py
+++ b/harmony/adapter.py
@@ -30,9 +30,8 @@ from . import util
 class BaseHarmonyAdapter(ABC):
     """
     Abstract base class for Harmony service adapters.  Service implementations
-    should inherit from this class and implement the `#invoke(self)` method to
-    adapt the Harmony message (`self.message`) into a service call and the
-    output of the service call into a response to Harmony (`self.completed_with_*`)
+    should inherit from this class and implement the `#invoke(self)` or `#process_item(self, item, source)`
+    method to adapt the Harmony message (`self.message`) into a service call
 
     Services may choose to override methods that do data downloads and result
     staging as well, if they use a different mechanism
@@ -115,7 +114,7 @@ class BaseHarmonyAdapter(ABC):
         if self.catalog:
             return (self.message, self._process_catalog_recursive(self.catalog))
 
-        # Current processing using callbacks
+        # Deprecated, processing using callbacks
         self._process_with_callbacks()
 
     def get_all_catalog_items(self, catalog: Catalog, follow_page_links=True):

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -242,7 +242,7 @@ def _invoke(adapter, metadata_dir):
         if isinstance(stac_output, list):
             hrefs = []
             for idx, catalog in enumerate(stac_output):
-                self_href = path.join(metadata_dir, f'catalog{idx}.json')
+                self_href = f'catalog{idx}.json'
                 catalog.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED, MultiCatalogLayoutStrategy(idx))
                 hrefs.append(self_href)
             json_str = json.dumps(hrefs)

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -48,6 +48,7 @@ class MultiCatalogLayoutStrategy(BestPracticesLayoutStrategy):
         """
         return path.join(parent_dir, f'catalog{self.index}.json')
 
+
 def setup_cli(parser):
     """
     Adds Harmony arguments to the CLI being parsed by the provided parser
@@ -248,7 +249,7 @@ def _invoke(adapter, metadata_dir):
             json_str = json.dumps(hrefs)
             write(path.join(metadata_dir, 'batch-catalogs.json'), json_str)
             write(path.join(metadata_dir, 'batch-count.txt'), f'{len(hrefs)}')
-        else: # assume stac_output is a single catalog
+        else:  # assume stac_output is a single catalog
             stac_output.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED)
 
         if not is_s3_metadata_dir:

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -240,10 +240,8 @@ def _invoke(adapter, metadata_dir):
             makedirs(metadata_dir, exist_ok=True)
         (out_message, stac_output) = adapter.invoke()
         if isinstance(stac_output, list):
-            print('is list!')
             hrefs = []
             for idx, catalog in enumerate(stac_output):
-                print(idx, catalog)
                 self_href = path.join(metadata_dir, f'catalog{idx}.json')
                 catalog.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED, MultiCatalogLayoutStrategy(idx))
                 hrefs.append(self_href)

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -241,14 +241,11 @@ def _invoke(adapter, metadata_dir):
             makedirs(metadata_dir, exist_ok=True)
         (out_message, stac_output) = adapter.invoke()
         if isinstance(stac_output, list):
-            hrefs = []
             for idx, catalog in enumerate(stac_output):
-                self_href = f'catalog{idx}.json'
                 catalog.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED, MultiCatalogLayoutStrategy(idx))
-                hrefs.append(self_href)
-            json_str = json.dumps(hrefs)
+            json_str = json.dumps([f'catalog{i}.json' for i, c in enumerate(stac_output)])
             write(path.join(metadata_dir, 'batch-catalogs.json'), json_str)
-            write(path.join(metadata_dir, 'batch-count.txt'), f'{len(hrefs)}')
+            write(path.join(metadata_dir, 'batch-count.txt'), f'{len(stac_output)}')
         else:  # assume stac_output is a single catalog
             stac_output.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED)
 

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -20,6 +20,7 @@ from harmony.util import (receive_messages, delete_message, change_message_visib
                           config, create_decrypter)
 from harmony.version import get_version
 from harmony.aws import is_s3, write_s3
+from harmony.s3_stac_io import write
 
 
 def setup_cli(parser):
@@ -221,8 +222,8 @@ def _invoke(adapter, metadata_dir):
                 catalog.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED)
                 hrefs.append(self_href)
             json_str = json.dumps(hrefs)
-            write_s3(path.join(metadata_dir, 'batch-catalogs.json'), json_str)
-            write_s3(path.join(metadata_dir, 'batch-count.txt'), f'{len(hrefs)}')
+            write(path.join(metadata_dir, 'batch-catalogs.json'), json_str)
+            write(path.join(metadata_dir, 'batch-count.txt'), f'{len(hrefs)}')
         else: # assume stac_output is a single catalog
             stac_output.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED)
 

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -12,6 +12,7 @@ from os import path, makedirs
 import datetime
 
 from pystac import Catalog, CatalogType
+from pystac.layout import BestPracticesLayoutStrategy
 
 from harmony.exceptions import CanceledException, HarmonyException
 from harmony.message import Message
@@ -22,6 +23,30 @@ from harmony.version import get_version
 from harmony.aws import is_s3, write_s3
 from harmony.s3_stac_io import write
 
+
+class MultiCatalogLayoutStrategy(BestPracticesLayoutStrategy):
+    """
+    Layout that adheres to what the Harmony server expects
+    when multiple catalogs are output by a service.
+    """
+
+    def __init__(self, index):
+        self.index = index
+
+    def get_catalog_href(self, cat, parent_dir, is_root):
+        """
+        Returns the catalog href, using its index number as
+        part of the file name, e.g. s3://outputs/catalog0.json.
+
+        Parameters
+        ----------
+        parent_dir : string
+            The parent directory of the catalog
+        Returns
+        -------
+        The catalog href, postfixed with catalog{idx}.json
+        """
+        return path.join(parent_dir, f'catalog{self.index}.json')
 
 def setup_cli(parser):
     """
@@ -215,11 +240,12 @@ def _invoke(adapter, metadata_dir):
             makedirs(metadata_dir, exist_ok=True)
         (out_message, stac_output) = adapter.invoke()
         if isinstance(stac_output, list):
+            print('is list!')
             hrefs = []
             for idx, catalog in enumerate(stac_output):
+                print(idx, catalog)
                 self_href = path.join(metadata_dir, f'catalog{idx}.json')
-                catalog.set_self_href(self_href)
-                catalog.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED)
+                catalog.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED, MultiCatalogLayoutStrategy(idx))
                 hrefs.append(self_href)
             json_str = json.dumps(hrefs)
             write(path.join(metadata_dir, 'batch-catalogs.json'), json_str)

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -213,7 +213,10 @@ def _invoke(adapter, metadata_dir):
         if not is_s3_metadata_dir:
             makedirs(metadata_dir, exist_ok=True)
         (out_message, out_catalog) = adapter.invoke()
-        out_catalog.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED)
+        if isinstance(out_catalog, list):
+            print('handle catalog list')
+        else:
+            out_catalog.normalize_and_save(metadata_dir, CatalogType.SELF_CONTAINED)
 
         if not is_s3_metadata_dir:
             with open(path.join(metadata_dir, 'message.json'), 'w') as file:

--- a/harmony/s3_stac_io.py
+++ b/harmony/s3_stac_io.py
@@ -48,8 +48,6 @@ def write(uri, txt):
     txt: The STAC contents.
     """
     parsed = urlparse(uri)
-    print('writing to ' + uri)
-    print(txt)
     if parsed.scheme == 's3':
         aws.write_s3(uri, txt)
     else:

--- a/harmony/s3_stac_io.py
+++ b/harmony/s3_stac_io.py
@@ -48,6 +48,8 @@ def write(uri, txt):
     txt: The STAC contents.
     """
     parsed = urlparse(uri)
+    print('writing to ' + uri)
+    print(txt)
     if parsed.scheme == 's3':
         aws.write_s3(uri, txt)
     else:

--- a/tests/test_cli_stac.py
+++ b/tests/test_cli_stac.py
@@ -119,6 +119,17 @@ class TestCliInvokeAction(unittest.TestCase):
             with open(os.path.join(self.workdir, 'error.json')) as file:
                 self.assertEqual(file.read(), '{"error": "Service request failed with an unknown error", "category": "Unknown"}')
 
+    def test_new(self):
+            with cli_parser(
+                    '--harmony-action', 'invoke',
+                    '--harmony-input', '{"test": "input"}',
+                    '--harmony-sources', 'example/source/catalog.json',
+                    '--harmony-metadata-dir', self.workdir) as parser:
+                args = parser.parse_args()
+                cli.run_cli(parser, args, MockMultiCatalogOutputAdapter, cfg=self.config)
+                output = Catalog.from_file(os.path.join(self.workdir, 'catalog1.json'))
+                print(output)
+                self.assertTrue(True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cli_stac.py
+++ b/tests/test_cli_stac.py
@@ -144,6 +144,12 @@ class TestCliInvokeAction(unittest.TestCase):
                     item_hrefs = [l.get_href() for l in cat.get_links('item')]
                     self.assertTrue(f'./item-1-from-catalog-{cat.id}/item-1-from-catalog-{cat.id}.json' in item_hrefs)
                     self.assertTrue(f'./item-2-from-catalog-{cat.id}/item-2-from-catalog-{cat.id}.json' in item_hrefs)
+                    item = Item.from_file(os.path.join(self.workdir, f'./item-1-from-catalog-{cat.id}/item-1-from-catalog-{cat.id}.json'))
+                    item_root_href = item.get_single_link('root').get_href()
+                    item_parent_href = item.get_single_link('parent').get_href()
+                    self.assertTrue(item_parent_href == item_root_href)
+                    self.assertEqual(item_root_href, f'../catalog{idx}.json')
+                    self.assertEqual(item_parent_href, f'../catalog{idx}.json')
                 with open(os.path.join(self.workdir, 'batch-count.txt')) as file:
                     self.assertEqual(file.read(), '3')
                 with open(os.path.join(self.workdir, 'batch-catalogs.json')) as file:

--- a/tests/test_cli_stac.py
+++ b/tests/test_cli_stac.py
@@ -154,9 +154,9 @@ class TestCliInvokeAction(unittest.TestCase):
                     self.assertEqual(file.read(), '3')
                 with open(os.path.join(self.workdir, 'batch-catalogs.json')) as file:
                     self.assertEqual(json.loads(file.read()),
-                        [os.path.join(self.workdir, "catalog0.json"),
-                         os.path.join(self.workdir, "catalog1.json"), 
-                         os.path.join(self.workdir, "catalog2.json")])
+                        ["catalog0.json",
+                         "catalog1.json", 
+                         "catalog2.json"])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cli_stac.py
+++ b/tests/test_cli_stac.py
@@ -18,14 +18,24 @@ class MockAdapter(BaseHarmonyAdapter):
     def invoke(self):
         MockAdapter.message = self.message
         return (self.message, self.catalog)
+    
+class MockMultiCatalogOutputAdapter(BaseHarmonyAdapter):
+    message = None
+    """
+    Dummy class to mock adapter calls, performing a no-op service
+    that returns multiple STAC catologs instead of one
+    """
+    def invoke(self):
+        MockAdapter.message = self.message
+        catalogs = [
+            Catalog('a', ''), Catalog('b', ''), Catalog('c', '')]
+        return (self.message, catalogs)
 
 
 class TestCliInvokeAction(unittest.TestCase):
     def setUp(self):
         self.workdir = mkdtemp()
         self.inputdir = mkdtemp()
-        # self.catalog = Catalog('test-id', 'test catalog')
-        # self.catalog.normalize_and_save(self.inputdir, CatalogType.SELF_CONTAINED)
         self.config = config_fixture()
         print(self.config)
 

--- a/tests/test_cli_stac.py
+++ b/tests/test_cli_stac.py
@@ -1,9 +1,10 @@
 import os
 from tempfile import mkdtemp
+from datetime import datetime
 import shutil
 import unittest
 
-from pystac import Catalog, CatalogType
+from pystac import Catalog, CatalogType, Item
 
 from harmony import cli, BaseHarmonyAdapter
 from harmony.exceptions import ForbiddenException
@@ -29,6 +30,14 @@ class MockMultiCatalogOutputAdapter(BaseHarmonyAdapter):
         MockAdapter.message = self.message
         catalogs = [
             Catalog('a', ''), Catalog('b', ''), Catalog('c', '')]
+        for cat in catalogs:
+            items = [
+                Item(f'item-1-from-catalog-{cat.id}', None, [0, 0, 1, 1],
+                     datetime.strptime('09/19/22 13:55:26', '%m/%d/%y %H:%M:%S'), {}),
+                Item(f'item-2-from-catalog-{cat.id}', None, [0, 0, 1, 2],
+                     datetime.strptime('09/19/22 13:55:26', '%m/%d/%y %H:%M:%S'), {})
+            ]
+            cat.add_items(items)
         return (self.message, catalogs)
 
 

--- a/tests/test_cli_stac.py
+++ b/tests/test_cli_stac.py
@@ -24,8 +24,8 @@ class TestCliInvokeAction(unittest.TestCase):
     def setUp(self):
         self.workdir = mkdtemp()
         self.inputdir = mkdtemp()
-        self.catalog = Catalog('test-id', 'test catalog')
-        self.catalog.normalize_and_save(self.inputdir, CatalogType.SELF_CONTAINED)
+        # self.catalog = Catalog('test-id', 'test catalog')
+        # self.catalog.normalize_and_save(self.inputdir, CatalogType.SELF_CONTAINED)
         self.config = config_fixture()
         print(self.config)
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1624

## Description
Allows service implementations to output multiple STAC catalogs. Formats/writes the STAC layout in a way that conforms to what Harmony already handles for existing services that do this without the service library (for services like Query CMR) -- e.g. catalog0.json, catalog1.json, batch-catalogs.json, batch-count.txt.

## Local Test Steps
Run `make test`. If you want to test end to end:
1 - checkout this branch
2 - in harmony-service-example, checkout the ["test-multi-stac" branch](https://github.com/nasa/harmony-service-example/compare/test-multi-stac) and run `make build-image LOCAL_SVCLIB_DIR=../harmony-service-lib-py`
3 - add this to your harmony .env
```
HARMONY_SERVICE_EXAMPLE_SERVICE_QUEUE_URLS='["harmonyservices/service-example:test-multi-stac,http://localstack:4566/queue/harmony-service-example.fifo"]'
HARMONY_SERVICE_EXAMPLE_IMAGE=harmonyservices/service-example:test-multi-stac
``` 
4 - in Harmony, packages/util/env.ts make sure that allEnv looks like this:
`const allEnv = { ...envDefaults, ...envOverrides, ...originalEnv };`
5 - start up harmony and services (make sure the "test-multi-stac" image is being used) and run http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233800343-EEDTEST&format=image/tiff
6 - inspect the STAC outputs at http://localhost:4566/local-artifact-bucket. You should see catalog0.json, catalog1.json, catalog2.json, batch-catalogs.json, batch-count.txt for the non-Query-CMR work item. The file contents should look somewhat similar to the Query CMR item output, though not identical as the service library defaults to using the STAC best practices layout strategy.

This is slightly different than what Query CMR adheres to, mainly with respect to STAC Items, in the following 2 ways: 
(1) [item paths](https://github.com/stac-utils/pystac/blob/7d1dc8c75ea6753fd8b15e2cb418c7040c9bee51/pystac/layout.py#L467) (are _NOT_ contained in a sub-directory like they are in the best practices layout strategy). (2) Query-CMR-generated STAC items also do not contain links that point back to the parent catalog.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)