### PR TITLE
HARMONY-1727: Add support of extraArgs to message for data operation v0.19.0

### DIFF
--- a/example/example_message.json
+++ b/example/example_message.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "../../harmony/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json",
-  "version": "0.18.0",
+  "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
+  "version": "0.19.0",
   "callback": "http://localhost/some-path",
   "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
   "user": "jdoe",
@@ -68,5 +68,8 @@
   "extendDimensions": [
     "lat",
     "lon"
-  ]
+  ],
+  "extraArgs": {
+    "cut": false
+  }
 }

--- a/tests/example_messages.py
+++ b/tests/example_messages.py
@@ -1,7 +1,7 @@
 minimal_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json",
-        "version": "0.18.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
+        "version": "0.19.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -19,8 +19,8 @@ minimal_message = """
 
 minimal_source_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json",
-        "version": "0.18.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
+        "version": "0.19.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -46,8 +46,8 @@ minimal_source_message = """
 
 full_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json",
-        "version": "0.18.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
+        "version": "0.19.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -180,6 +180,17 @@ full_message = """
             }]
         },
         "concatenate": true,
-        "extendDimensions": ["lat", "lon"]
+        "extendDimensions": ["lat", "lon"],
+        "extraArgs": {
+            "cut": false,
+            "intParam": 100,
+            "floatParam": 123.456,
+            "stringParam": "value",
+            "arrayParam": [1, 2, 3],
+            "objectParam": {
+                "name": "obj1",
+                "attributes": ["x", "y"]
+            }
+        }
     }
 """

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -13,7 +13,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_full_message_it_parses_it_into_objects(self):
         message = Message(full_message)
 
-        self.assertEqual(message.version, '0.18.0')
+        self.assertEqual(message.version, '0.19.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -79,12 +79,13 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.subset.dimensions[1].min, None)
         self.assertEqual(message.subset.dimensions[1].max, 10)
         self.assertEqual(message.extendDimensions, ["lat", "lon"])
+        self.assertEqual(message.extraArgs['cut'], False)
 
 
     def test_when_provided_a_minimal_message_it_parses_it_into_objects(self):
         message = Message(minimal_message)
 
-        self.assertEqual(message.version, '0.18.0')
+        self.assertEqual(message.version, '0.19.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -104,7 +105,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_message_with_minimal_source_it_parses_it_into_objects(self):
         message = Message(minimal_source_message)
 
-        self.assertEqual(message.version, '0.18.0')
+        self.assertEqual(message.version, '0.19.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.user, 'jdoe')
         self.assertEqual(message.accessToken, 'ABCD1234567890')
@@ -174,3 +175,14 @@ class TestMessage(unittest.TestCase):
 
         # Point property is generated
         self.assertEqual(message.subset.point, [-160.2, 80.2])
+
+    def test_extra_args(self):
+        message = Message(full_message)
+
+        self.assertEqual(message.extraArgs['cut'], False)
+        self.assertEqual(message.extraArgs['intParam'], 100)
+        self.assertEqual(message.extraArgs['floatParam'], 123.456)
+        self.assertEqual(message.extraArgs['stringParam'], 'value')
+        self.assertEqual(message.extraArgs['arrayParam'], [1, 2, 3])
+        self.assertEqual(message.extraArgs['objectParam'], {'name': 'obj1', 'attributes': ['x', 'y']})
+        self.assertIsNone(message.extraArgs['nonExistent'])


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1727

## Description
Add support of extraArgs to message for data operation v0.19.0

## Local Test Steps
`make test` is successful and test with harmony server and service changes locally. See corresponding harmony PR for details.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)