### PR TITLE
HARMONY-1719: Add request-id to download requests to support Cloud Metrics

### DIFF
--- a/harmony/adapter.py
+++ b/harmony/adapter.py
@@ -21,6 +21,7 @@ from deprecation import deprecated
 from pystac import Catalog, Item, Asset, read_file
 
 from harmony.exceptions import CanceledException
+from harmony.http import request_context
 from harmony.logging import build_logger
 from harmony.message import Temporal
 from harmony.util import touch_health_check_file
@@ -69,6 +70,10 @@ class BaseHarmonyAdapter(ABC):
         if catalog is None:
             warn('Invoking adapter.BaseHarmonyAdapter without a STAC catalog is deprecated',
                  DeprecationWarning, stacklevel=2)
+
+        # set the request ID in the global context so we can use it in other places
+        request_id = message.requestId if hasattr(message, 'requestId') else None
+        request_context['request_id'] = request_id
 
         self.message = message
         self.catalog = catalog

--- a/harmony/http.py
+++ b/harmony/http.py
@@ -39,6 +39,7 @@ MAX_RETRY_DELAY_SECS = 90
 # without adding extra function arguments
 request_context = {}
 
+
 def get_retry_delay(retry_num: int, max_delay: int = MAX_RETRY_DELAY_SECS) -> int:
     """The number of seconds to sleep before retrying. Exponential backoff starting
     from 5 seconds up the max_delay. So with a max delay of 60 the retry periods
@@ -134,6 +135,7 @@ def _earthdata_session():
     """Constructs an EarthdataSession for use to download one or more files."""
     return EarthdataSession()
 
+
 def _add_api_request_uuid(url):
     request_id = request_context.get('request_id')
 
@@ -163,6 +165,7 @@ def _add_api_request_uuid(url):
     )
 
     return new_url
+
 
 def _download(
     config, url: str,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -61,6 +61,21 @@ class TestDownload(unittest.TestCase):
         client.assert_called_with(service_name='s3', config=boto_cfg_instance, region_name=ANY)
 
     @patch('harmony.util.get_version')
+    @patch('harmony.aws.download')
+    @patch('harmony.aws.Config')
+    def test_s3_download_does_not_set_api_request_uuid(self, boto_cfg, aws_download, get_version):
+        request_context['request_id'] = 'abc123'
+        app_name = 'gdal-subsetter'
+        fake_lib_version = '0.1.0'
+        get_version.return_value = fake_lib_version
+        cfg = config_fixture(app_name=app_name)
+        boto_cfg_instance = MagicMock()
+        boto_cfg.return_value = boto_cfg_instance
+        with patch('builtins.open', mock_open()):
+            util.download('s3://example/file.txt', 'tmp', access_token='', cfg=cfg)
+        aws_download.assert_called_with(ANY, 's3://example/file.txt', ANY, ANY )
+
+    @patch('harmony.util.get_version')
     @patch.object(Session, 'get')
     def test_http_download_sets_api_request_uuid(self, get, get_version):
         request_context['request_id'] = 'abc123'


### PR DESCRIPTION
## Jira Issue ID
Harmony-1719


## Description
Adds `A-api-request-uuid` query parameter to http/https download requests to support end-to-end tracking in Cloud Metrics

## Local Test Steps
1. Checkout this branch
2. Clone the harmony-example-service repo
3. Build the service example image with this branch
```
 make build-image LOCAL_SVCLIB_DIR=../harmony-service-lib-py
```
4. Start up harmony with `harmony-service-example` in `LOCALLY_DEPLOYED_SERVICES` in your .env file.
5. Tail the logs on the `harmony-service-example` pod.
6. Execute the following query
```
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/red_var,blue_var,green_var/coverage/rangeset/?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1
```
7. Look for the download timing log entry in the service log and verify that the `A-api-request-uuid` parameter is included in the download url, e.g.,
```
2024-04-16T18:06:08.662Z [debug]: 2024-04-16 18:06:08,660 [INFO] [harmony-service.download:397] timing.download.start https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/001_00_7f00ff_global.nc?A-api-request-uuid=daabdd53-0c9a-45d0-b797-e00aa0f49a4a
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~