### PR TITLE
Harmony 1756 - Use trusted publisher token to publish to PyPi

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,6 @@ jobs:
         BRANCH: ${{ github.event.release.target_commitish }}
       run: |
         VERSION=$(echo "${VERSION_TAG}" | cut -c2-) make build
-        make publish
 
         # Setup git
         # https://api.github.com/users/github-actions%5Bbot%5D
@@ -36,3 +35,25 @@ jobs:
 
         git tag --force "${VERSION_TAG}"
         git push --force origin "${VERSION_TAG}"
+    - name: upload dists
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-dists
+        path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,6 @@ jobs:
         python-version: '3.8'
     - shell: bash
       env:
-        REPO_PASS: ${{ secrets.PYPI }}
         VERSION_TAG: ${{ github.event.release.tag_name }}
         BRANCH: ${{ github.event.release.target_commitish }}
       run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,7 +44,7 @@ jobs:
   pypi-publish:
     runs-on: ubuntu-latest
     needs:
-      - release-build
+      - build
     permissions:
       id-token: write
 

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -7,7 +7,7 @@ Convenience exports for the Harmony library
 """
 
 # Automatically updated by `make build`
-__version__ = "v1.0.26"
+__version__ = "1756"
 
 from .adapter import BaseHarmonyAdapter
 from .cli import setup_cli, is_harmony_cli, run_cli

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -7,7 +7,7 @@ Convenience exports for the Harmony library
 """
 
 # Automatically updated by `make build`
-__version__ = "1756"
+__version__ = "1756beta"
 
 from .adapter import BaseHarmonyAdapter
 from .cli import setup_cli, is_harmony_cli, run_cli

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -7,7 +7,7 @@ Convenience exports for the Harmony library
 """
 
 # Automatically updated by `make build`
-__version__ = "1756beta"
+__version__ = "v1.0.26"
 
 from .adapter import BaseHarmonyAdapter
 from .cli import setup_cli, is_harmony_cli, run_cli


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1756

## Description
Changes GitHub publish action to use trusted publisher token instead of password stored in GitHub secret.

## Local Test Steps
1. Click on the 'Releases' link in the main page of this GitHub repo
2. Click on 'Draft release' button.
3. Create a dummy tag
4. Choose this branch instead of 'main'
5. Fill in title and description with whatever
6. Choose "pre-production release" checkbox 
7. Click on 'Publish release'
8. Check to the 'Actions' tab on the page and make sure the publish action succeeds
9. Go to pypi.org and search for `harmony-service-lib`
10. Check on the releases and verify that your release is there
11. Delete your test release

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)