### PR TITLE
Harmony 1764 add support for specifying data operation using a file

### DIFF
--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -65,6 +65,8 @@ def setup_cli(parser):
     parser.add_argument('--harmony-input',
                         help=('the input data for the action provided by Harmony, required for '
                               '--harmony-action=invoke'))
+    parser.add_argument('--harmony-input-file',
+                        help=('the optional path to the input data for the action provided by Harmony, required for '))
     parser.add_argument('--harmony-sources',
                         help=('file path that contains a STAC catalog with items and metadata to '
                               'be processed by the service.  Required for non-deprecated '

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -323,11 +323,16 @@ def run_cli(parser, args, AdapterClass, cfg=None):
     if args.harmony_wrap_stdout:
         setup_stdout_log_formatting(cfg)
 
+    # read in the operation file passed in with --harmony-input-file if any
+    if bool(args.harmony_input_file):
+        with open(args.harmony_input_file, 'r') as f:
+            args.harmony_input = f.read()
+
     if args.harmony_action == 'invoke':
         start_time = datetime.datetime.now()
         if not bool(args.harmony_input):
             parser.error(
-                '--harmony-input must be provided for --harmony-action=invoke')
+                '--harmony-input or --harmony-input-file must be provided for --harmony-action=invoke')
         elif not bool(args.harmony_sources):
             successful = _invoke_deprecated(AdapterClass, args.harmony_input, cfg)
             if not successful:

--- a/harmony/cli.py
+++ b/harmony/cli.py
@@ -66,7 +66,7 @@ def setup_cli(parser):
                         help=('the input data for the action provided by Harmony, required for '
                               '--harmony-action=invoke'))
     parser.add_argument('--harmony-input-file',
-                        help=('the optional path to the input data for the action provided by Harmony, required for '))
+                        help=('the optional path to the input data for the action provided by Harmony'))
     parser.add_argument('--harmony-sources',
                         help=('file path that contains a STAC catalog with items and metadata to '
                               'be processed by the service.  Required for non-deprecated '


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1764

## Description
This change adds a new CLI parameter, --harmony-input-file, with which the data operation can be passed on the file system rather than as a command line parameter using --harmony-input. This is needed to support large data operations that were exceeding stack limits when passed using --harmony-input.

## Local Test Steps
1. Check out this branch
2. Rebuild the trajectory-subsetter image using this branch of harmony-service-lib-py (need to chance requirements.txt)
3. Push the service to the harmony sandbox
4. Do a sandbox deployment including the service in LOCALLY_DEPLOYED_SERVICES
5. Run a query with a large number of variables


## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)