### PR TITLE
HARMONY-1866 - Enable _reformatted prefix in output file names.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,6 @@ test:
 test-no-warnings:
 	pytest --disable-warnings --cov=harmony tests
 
+# HARMONY-1908 - Ignore jinja2 vulnerability (safety ID 70612)
 cve-check:
-	safety check
+	safety check -i 70612

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ version:
 	sed -i.bak "s/__version__ .*/__version__ = \"$(VERSION)\"/" harmony/__init__.py && rm harmony/__init__.py.bak
 
 build: clean version
-	python -m pip install --upgrade --quiet setuptools wheel twine
-	python setup.py --quiet sdist bdist_wheel
+	python -m pip install --upgrade --quiet setuptools wheel twine build
+	python -m build
 
 publish: build
 	python -m twine check dist/*

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,12 +4,13 @@ Faker ~= 8.1.3
 flake8 ~= 5.0.4
 ipython ~= 8.10.0
 jedi ~= 0.17.2
+packaging ~= 24.1
 parameterized ~= 0.7
+pycodestyle ~= 2.9.1
 pytest ~= 7.2.0
 pytest-cov ~=2.11
 pytest-mock ~=3.5
 python-language-server ~= 0.35
 responses ~=0.22.0
-safety ~= 2.3.5
-pycodestyle ~= 2.9.1
-setuptools ~= 68.1.2
+safety ~= 3.2.7
+setuptools == 70.0.0

--- a/harmony/util.py
+++ b/harmony/util.py
@@ -490,10 +490,17 @@ def nop_decrypter(ciphertext):
     return ciphertext
 
 
-def generate_output_filename(filename, ext=None, variable_subset=None, is_regridded=False, is_subsetted=False):
+def generate_output_filename(
+    filename: str,
+    ext: str = None,
+    variable_subset: list[str] = None,
+    is_regridded: bool = False,
+    is_subsetted: bool = False,
+    is_reformatted: bool = False
+) -> str:
     """
     Return an output filename for the given granules according to our naming conventions:
-    {original filename without suffix}(_{single var})?(_regridded)?(_subsetted)?.<ext>
+    {original filename without suffix}(_{single var})?(_regridded)?(_subsetted)?(_reformatted)?.<ext>
 
     Parameters
     ----------
@@ -507,6 +514,8 @@ def generate_output_filename(filename, ext=None, variable_subset=None, is_regrid
             True if a regridding operation has been performed (default: False)
         is_subsetted : bool, optional
             True if a subsetting operation has been performed (default: False)
+        is_reformatted : bool, optional
+            True if a reformatting operation has been performed (default: False)
 
     Returns
     -------
@@ -536,6 +545,9 @@ def generate_output_filename(filename, ext=None, variable_subset=None, is_regrid
         suffixes.append('_regridded')
     if is_subsetted:
         suffixes.append('_subsetted')
+    if is_reformatted:
+        suffixes.append('_reformatted')
+
     suffixes.append(ext)
 
     result = original_basename

--- a/harmony/util.py
+++ b/harmony/util.py
@@ -49,6 +49,8 @@ Optional:
                           alive.
     MAX_DOWNLOAD_RETRIES: Number of times to retry HTTP download calls that fail due to transient errors.
 """
+# Remove this import when Python 3.8 is no longer supported
+from __future__ import annotations
 
 from base64 import b64decode
 from collections import namedtuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+# License and classifier list:
+# https://pypi.org/pypi?%3Aaction=list_classifiers
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+authors = [
+    {name = "NASA EOSDIS Harmony Team", email = "christopher.d.durbin@nasa.gov"}
+]
+classifiers = [
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Operating System :: OS Independent",
+]
+description = "A library for Python-based Harmony services to parse incoming message, fetch data, stage data, and call back to Harmony."
+dynamic = ["dependencies", "optional-dependencies", "version"]
+license = { text = "License :: OSI Approved :: Apache Software License" }
+name = "harmony-service-lib"
+readme = "README.md"
+requires-python = ">= 3.8"
+
+[project.scripts]
+harmony-service-lib = "harmony.cli.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/nasa/harmony-service-lib-py"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+optional-dependencies = {dev = {file = ["dev-requirements.txt"]}}
+# Will read __version__ from harmony.__init__.py
+version = {attr = "harmony.__version__"}
+
+[tool.setuptools.packages.find]
+exclude = ["contrib", "docs", "tests*"]

--- a/setup.py
+++ b/setup.py
@@ -7,68 +7,9 @@
 # To upload this file to PyPI you must build it then upload it:
 # python setup.py sdist bdist_wheel  # build in 'dist' folder
 # python-m twine upload dist/*  # 'twine' must be installed: 'pip install twine'
+#
+# 2024-09-24 - Updated to use pyproject.toml.
 
-import ast
-import io
-import re
-import os
-from setuptools import find_packages, setup
+from setuptools import setup
 
-DEPENDENCIES = []
-with open("requirements.txt", "r") as f:
-    DEPENDENCIES = f.read().strip().split('\n')
-
-DEV_DEPENDENCIES = []
-with open("dev-requirements.txt", "r") as f:
-    DEV_DEPENDENCIES = f.read().strip().split('\n')
-
-EXCLUDE_FROM_PACKAGES = ["contrib", "docs", "tests*"]
-CURDIR = os.path.abspath(os.path.dirname(__file__))
-
-with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
-    README = f.read()
-
-
-def get_version():
-    main_file = os.path.join(CURDIR, "harmony", "__init__.py")
-    _version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")
-    with open(main_file, "r", encoding="utf8") as f:
-        match = _version_re.search(f.read())
-        version = match.group("version") if match is not None else '"unknown"'
-    return str(ast.literal_eval(version))
-
-
-setup(
-    name="harmony-service-lib",
-    version=get_version(),
-    author="NASA EOSDIS Harmony Team",
-    author_email="patrick@element84.com",
-    description=("A library for Python-based Harmony services to parse incoming messages, "
-                 "fetch data, stage data, and call back to Harmony"),
-    long_description=README,
-    long_description_content_type="text/markdown",
-    url="https://github.com/nasa/harmony-service-lib-py",
-    packages=find_packages(exclude=EXCLUDE_FROM_PACKAGES),
-    include_package_data=True,
-    keywords=[],
-    scripts=[],
-    entry_points={
-        "console_scripts": ["harmony-service-lib=harmony.cli.__main__:main"]
-    },
-    zip_safe=False,
-    install_requires=DEPENDENCIES,
-    # HARMONY-1188 - uncomment this
-    # extras_require={
-    #     'dev': DEV_DEPENDENCIES
-    # },
-    test_suite="tests",
-    python_requires=">=3.8",
-    # license and classifier list:
-    # https://pypi.org/pypi?%3Aaction=list_classifiers
-    license="License :: OSI Approved :: Apache Software License",
-    classifiers=[
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Operating System :: OS Independent"
-    ],
-)
+setup()


### PR DESCRIPTION
## Jira Issue ID

HARMONY-1866

## Description

This work comes off the back of the net2cog production readiness check-in. net2cog currently needs custom code to determine the output file name for its reformatted products, because the common functionality in this library doesn't account for reformatting operations. This PR extends the existing `generate_output_filename` function to be able to add a `_reformatted` suffix when appropriate.

I'm totally open to a better choice of suffix. net2cog uses `_converted` for example, "Reformatting" matches with a lot of the terminology that's been floating around in our convergence meetings, so I think that's why I opted for that initially.

**CI/CD failures:**

Looks like the `safety` check is failing due to the version of `setuptools` used. I looked a bit more into that, and it can be resolved by bumping to:

* `setuptools ~= 74.1.2`
* `packaging ~= 24.0` (note this would need to be explicitly listed in `dev-requirements.txt`).
* `safety ~= 3.2.7`

...but, then we get to issues with `setup.py` being deprecated in favour of `pyproject.toml`. I think it's a bit of a big stretch to start making these sorts of changes in this PR, though.

## Local Test Steps

* Pull this branch.
* Create a virtual environment that has installed everything from `requirements.txt`.
* Use the function to see how it behaves:

```
from harmony.util import generate_output_filename

# Play around with the arguments below to test it out:
generate_output_filename('random_name.nc', '.extension', is_subsetted=False, is_regridded=False, is_reformatted=True)
```

Things to check:

* Consistency in ordering of suffices.
* Behaviour with/without variables. (E.g., single variable in list is included in file name, no variables or multiple variables not included)

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* ~~Documentation updated (if needed)~~