### PR TITLE
HARMONY-1912: Add support for the average parameter which specifies the averaging method to use for averaging services

### DIFF
--- a/example/example_message.json
+++ b/example/example_message.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
-  "version": "0.19.0",
+  "$schema": "../../harmony/app/schemas/data-operation/0.20.0/data-operation-v0.20.0.json",
+  "version": "0.20.0",
   "callback": "http://localhost/some-path",
   "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
   "user": "jdoe",
@@ -65,6 +65,7 @@
     }]
   },
   "concatenate": false,
+  "average": "time",
   "extendDimensions": [
     "lat",
     "lon"

--- a/harmony_service_lib/message.py
+++ b/harmony_service_lib/message.py
@@ -617,6 +617,8 @@ class Message(JsonObject):
     concatenate: bool
         True if the service should concatenate multiple input files into a single output
         file and false otherwise.
+    average: string
+        The averaging method to use
     extendDimensions: list
         A list of dimensions to extend.
     extraArgs: object
@@ -657,6 +659,7 @@ class Message(JsonObject):
                 'subset',
                 'temporal',
                 'concatenate',
+                'average',
                 'extendDimensions',
                 'extraArgs'
             ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3 ~= 1.14
 deprecation ~= 2.1.0
 pynacl ~= 1.4
-pystac >= 1.0.0
+pystac>=1.0.0,<1.11.0 # Locked due to HARMONY-1922
 python-json-logger ~= 2.0.1
 requests ~= 2.24
 urllib3 ~= 1.26.9

--- a/tests/example_messages.py
+++ b/tests/example_messages.py
@@ -1,7 +1,7 @@
 minimal_message = """
     {
         "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
-        "version": "0.19.0",
+        "version": "0.20.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -20,7 +20,7 @@ minimal_message = """
 minimal_source_message = """
     {
         "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
-        "version": "0.19.0",
+        "version": "0.20.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -47,7 +47,7 @@ minimal_source_message = """
 full_message = """
     {
         "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
-        "version": "0.19.0",
+        "version": "0.20.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -180,6 +180,7 @@ full_message = """
             }]
         },
         "concatenate": true,
+        "average": "time",
         "extendDimensions": ["lat", "lon"],
         "extraArgs": {
             "cut": false,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -22,6 +22,7 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.isSynchronous, True)
         self.assertEqual(message.accessToken, 'ABCD1234567890')
         self.assertEqual(message.concatenate, True)
+        self.assertEqual(message.average, 'time')
         self.assertEqual(message.sources[0].collection, 'C0001-EXAMPLE')
         self.assertEqual(message.sources[0].shortName, 'example_1_data')
         self.assertEqual(message.sources[0].versionId, '1')

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -13,7 +13,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_full_message_it_parses_it_into_objects(self):
         message = Message(full_message)
 
-        self.assertEqual(message.version, '0.19.0')
+        self.assertEqual(message.version, '0.20.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -86,7 +86,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_minimal_message_it_parses_it_into_objects(self):
         message = Message(minimal_message)
 
-        self.assertEqual(message.version, '0.19.0')
+        self.assertEqual(message.version, '0.20.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -106,7 +106,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_message_with_minimal_source_it_parses_it_into_objects(self):
         message = Message(minimal_source_message)
 
-        self.assertEqual(message.version, '0.19.0')
+        self.assertEqual(message.version, '0.20.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.user, 'jdoe')
         self.assertEqual(message.accessToken, 'ABCD1234567890')


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1912

## Description
Adds support for the average parameter which specifies the averaging method to use for averaging services. This will be for the Giovanni services to know whether the request is for 'time' or 'area' averaging.

## Local Test Steps
Test with the main harmony repo changes.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)