### PR TITLE
HARMONY-1922: Add geometry to STAC item  when bbox is defined, but geometry is not

### DIFF
--- a/harmony_service_lib/adapter.py
+++ b/harmony_service_lib/adapter.py
@@ -181,9 +181,13 @@ class BaseHarmonyAdapter(ABC):
         result.clear_items()
         source = None
         for item in items:
+            cloned_item = item.clone()
+            # if there is a bbox, but no geometry, create a geometry from the bbox
+            if cloned_item.bbox and not cloned_item.geometry:
+                cloned_item.geometry = util.bbox_to_geometry(cloned_item.bbox)
             item_count = item_count + 1
-            source = source or self._get_item_source(item)
-            output_item = self.process_item(item.clone(), source)
+            source = source or self._get_item_source(cloned_item)
+            output_item = self.process_item(cloned_item, source)
             if output_item:
                 # Ensure the item gets a new ID
                 if output_item.id == item.id:
@@ -209,7 +213,7 @@ class BaseHarmonyAdapter(ABC):
         completed = 0
         for source in self.message.sources:
             for granule in source.granules:
-                item = Item(granule.id, None, granule.bbox, None, {
+                item = Item(granule.id, util.bbox_to_geometry(granule.bbox), granule.bbox, None, {
                     'start_datetime': granule.temporal.start,
                     'end_datetime': granule.temporal.end
                 })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3 ~= 1.14
 deprecation ~= 2.1.0
 pynacl ~= 1.4
-pystac ~= 1.11.0
+pystac >= 1.0.0
 python-json-logger ~= 2.0.1
 requests ~= 2.24
 urllib3 ~= 1.26.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3 ~= 1.14
 deprecation ~= 2.1.0
 pynacl ~= 1.4
-pystac>=1.0.0,<1.11.0 # Locked due to HARMONY-1922
+pystac ~= 1.11.0
 python-json-logger ~= 2.0.1
 requests ~= 2.24
 urllib3 ~= 1.26.9

--- a/tests/test_adapter_stac.py
+++ b/tests/test_adapter_stac.py
@@ -165,7 +165,6 @@ class TestBaseHarmonyAdapterDefaultInvoke(unittest.TestCase):
         adapter = AdapterTester(message, catalog, config=self.config)
         all_items = list(adapter.get_all_catalog_items(catalog, True))
         self.assertEqual(all_items, [ *items_a, *items_b ])
-        
 
     def test_unaltered_ids_are_assigned_new_uuids(self):
         catalog = Catalog('0', 'Catalog 0')
@@ -218,7 +217,10 @@ class TestBaseHarmonyAdapterDefaultInvoke(unittest.TestCase):
                 'end_datetime': '2002-02-02T02:02:02Z',
                 'datetime': None
             },
-            'geometry': None,
+            'geometry': {
+                'coordinates': [[[-1, -2], [-1, 4], [3, 4], [3, -2], [-1, -2]]],
+                'type': 'Polygon'
+            },
             'links': [],
             'assets': {
                 'data': {
@@ -239,7 +241,10 @@ class TestBaseHarmonyAdapterDefaultInvoke(unittest.TestCase):
                 'end_datetime': '2004-04-04T04:04:04Z',
                 'datetime': None
             },
-            'geometry': None,
+            'geometry': {
+                'coordinates': [[[-5, -6], [-5, 8], [7, 8], [7, -6], [-5, -6]]],
+                'type': 'Polygon'
+            },
             'links': [],
             'assets': {
                 'data': {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1922

## Description
the STAC spec requires a geometry if a STAC item has a bbox. This is now enforced by pystac. This change adds the
geometry field by creating a Polygon to match the bbox if there is a bbox, but not a geometry defined for the STAC item.

## Local Test Steps
1. Run `make test`
2. Rebuild the `harmony-service-example` service image with this branch and deploy to your local environment. Verify that queries still work

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~