### PR TITLE
HARMONY-1938: Update code to omit Authorization header when redirected to a presigned S3 URL

### DIFF
--- a/tests/test_earthdata.py
+++ b/tests/test_earthdata.py
@@ -31,12 +31,26 @@ def test_authdata_auth_creates_correct_header(faker):
     assert token in request.headers['Authorization']
 
 
-def test_earthdata_auth_given_edl_url_adds_auth_header(earthdata_auth):
+def test_earthdata_auth_adds_auth_header_(earthdata_auth):
     request = FakeRequest()
 
     earthdata_auth(request)
 
     assert 'Authorization' in request.headers
+
+def test_earthdata_auth_removes_auth_header_when_X_Amz_Algorithm_is_set(earthdata_auth):
+    request = FakeRequest(url='https://presigned.s3.url.com?X-Amz-Algorithm=foo')
+
+    earthdata_auth(request)
+
+    assert 'Authorization' not in request.headers
+
+def test_earthdata_auth_removes_auth_header_when_signature_is_set(earthdata_auth):
+    request = FakeRequest(url='https://presigned.s3.url.com?Signature=bar')
+
+    earthdata_auth(request)
+
+    assert 'Authorization' not in request.headers
 
 def test_earthdata_session_given_no_auth_delegates_to_super(monkeypatch):
     called = False


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1938

## Description
The latest service library changes were not working when attempting to download a file that resulted in a redirect to a pre-signed S3 URL. The issue was that the Authorization header with the EDL bearer token was being sent to the redirect location which had conflicting query parameters (Signature and X-Amz-Algorithm indicate a different authorization method).

Now the library will pass in the Authorization header unless one of those query parameters is present in the request.

## Local Test Steps

This cannot be tested locally - it needs to be tested in an AWS environment.

1. Build the harmony-service-example service using the service library in this branch.
2. Push the image to your sandbox (use a tag other than latest so that it does not conflict with the image used for the main sandbox).
3. Submit a request {root_lb_url}/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng
4. Verify it completes successfully (meaning the bearer token was passed in properly in the Authorization header to the correct endpoints, but omitted from the presigned S3 URL redirect).

You can currently see the broken behavior in the Harmony SIT environment with https://harmony.sit.earthdata.nasa.gov/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)