### PR TITLE
HARMONY-1983: As a service provider I want the service library to provide a way of indicating an empty result.

### DIFF
--- a/harmony_service_lib/cli.py
+++ b/harmony_service_lib/cli.py
@@ -106,7 +106,7 @@ def is_harmony_cli(args):
     return args.harmony_action is not None
 
 
-def _write_error(metadata_dir, message, category='Unknown'):
+def _write_error(metadata_dir, message, category='Unknown', level='Error'):
     """
     Writes the given error message to error.json in the provided metadata dir
 
@@ -118,8 +118,10 @@ def _write_error(metadata_dir, message, category='Unknown'):
         The error message to write
     category : string
         The error category to write
+    level : string
+        The error level to write, can be 'Error' or 'Warning'. Default to 'Error'
     """
-    error_data = {'error': message, 'category': category}
+    error_data = {'error': message, 'category': category, 'level': level}
     if is_s3(metadata_dir):
         json_str = json.dumps(error_data)
         write_s3(f'{metadata_dir}error.json', json_str)
@@ -204,7 +206,7 @@ def _invoke(adapter, metadata_dir):
                 json.dump(out_message.output_data, file)
     except HarmonyException as err:
         logging.error(err, exc_info=1)
-        _write_error(metadata_dir, err.message, err.category)
+        _write_error(metadata_dir, err.message, err.category, err.level)
         raise
     except BaseException as err:
         logging.error(err, exc_info=1)

--- a/harmony_service_lib/exceptions.py
+++ b/harmony_service_lib/exceptions.py
@@ -37,6 +37,7 @@ class ServerException(HarmonyException):
     def __init__(self, message=None):
         super().__init__(message, 'Server')
 
+
 class NoDataException(HarmonyException):
     """Class for throwing an exception indicating service found no data to process """
 

--- a/harmony_service_lib/exceptions.py
+++ b/harmony_service_lib/exceptions.py
@@ -41,5 +41,5 @@ class ServerException(HarmonyException):
 class NoDataException(HarmonyException):
     """Class for throwing an exception indicating service found no data to process """
 
-    def __init__(self, message=None):
+    def __init__(self, message='No data found to process'):
         super().__init__(message, 'NoData', 'Warning')

--- a/harmony_service_lib/exceptions.py
+++ b/harmony_service_lib/exceptions.py
@@ -7,11 +7,14 @@ class HarmonyException(Exception):
         Explanation of the error
     category : string
         Classification of the type of harmony error
+    level : string
+        The level of the error, can be 'Error' or 'Warning'.
     """
 
-    def __init__(self, message, category='Service'):
+    def __init__(self, message, category='Service', level='Error'):
         self.message = message
         self.category = category
+        self.level = level
 
 
 class CanceledException(HarmonyException):
@@ -33,3 +36,9 @@ class ServerException(HarmonyException):
 
     def __init__(self, message=None):
         super().__init__(message, 'Server')
+
+class NoDataException(HarmonyException):
+    """Class for throwing an exception indicating service found no data to process """
+
+    def __init__(self, message=None):
+        super().__init__(message, 'NoData', 'Warning')

--- a/tests/test_cli_stac.py
+++ b/tests/test_cli_stac.py
@@ -8,7 +8,7 @@ import json
 from pystac import Catalog, CatalogType, Item
 
 from harmony_service_lib import cli, BaseHarmonyAdapter
-from harmony_service_lib.exceptions import ForbiddenException
+from harmony_service_lib.exceptions import ForbiddenException, NoDataException
 from tests.util import cli_parser, config_fixture
 
 
@@ -17,9 +17,11 @@ class MockAdapter(BaseHarmonyAdapter):
     """
     Dummy class to mock adapter calls, performing a no-op service
     """
+
     def invoke(self):
         MockAdapter.message = self.message
         return (self.message, self.catalog)
+
 
 class MockMultiCatalogOutputAdapter(BaseHarmonyAdapter):
     message = None
@@ -27,6 +29,7 @@ class MockMultiCatalogOutputAdapter(BaseHarmonyAdapter):
     Dummy class to mock adapter calls, performing a no-op service
     that returns multiple STAC catologs instead of one
     """
+
     def invoke(self):
         MockAdapter.message = self.message
         catalogs = [
@@ -106,7 +109,9 @@ class TestCliInvokeAction(unittest.TestCase):
 
             self.assertTrue('Something bad happened' in str(context.exception))
             with open(os.path.join(self.workdir, 'error.json')) as file:
-                self.assertEqual(file.read(), '{"error": "Something bad happened", "category": "Forbidden"}')
+                self.assertEqual(
+                    file.read(),
+                    '{"error": "Something bad happened", "category": "Forbidden", "level": "Error"}')
 
     def test_when_the_backend_service_throws_an_unknown_error_it_writes_a_generic_error_to_the_output_dir(self):
         with cli_parser(
@@ -125,36 +130,61 @@ class TestCliInvokeAction(unittest.TestCase):
 
             self.assertTrue('Something bad happened' in str(context.exception))
             with open(os.path.join(self.workdir, 'error.json')) as file:
-                self.assertEqual(file.read(), '{"error": "Service request failed with an unknown error", "category": "Unknown"}')
+                self.assertEqual(
+                    file.read(),
+                    '{"error": "Service request failed with an unknown error", "category": "Unknown", "level": "Error"}')
+
+    def test_when_the_backend_service_throws_a_known_warning_it_writes_the_warning_to_the_output_dir(self):
+        with cli_parser(
+                '--harmony-action', 'invoke',
+                '--harmony-input', '{"test": "input"}',
+                '--harmony-sources', 'example/source/catalog.json',
+                '--harmony-metadata-dir', self.workdir) as parser:
+
+            class MockImpl(MockAdapter):
+                def invoke(self):
+                    raise NoDataException('There is no data found')
+
+            args = parser.parse_args()
+            with self.assertRaises(Exception) as context:
+                cli.run_cli(parser, args, MockImpl, cfg=self.config)
+
+            self.assertTrue('There is no data found' in str(context.exception))
+            with open(os.path.join(self.workdir, 'error.json')) as file:
+                self.assertEqual(
+                    file.read(),
+                    '{"error": "There is no data found", "category": "NoData", "level": "Warning"}')
 
     def test_when_multi_catalog_output_it_saves_with_particular_layout(self):
-            with cli_parser(
-                    '--harmony-action', 'invoke',
-                    '--harmony-input', '{"test": "input"}',
-                    '--harmony-sources', 'example/source/catalog.json',
-                    '--harmony-metadata-dir', self.workdir) as parser:
-                args = parser.parse_args()
-                cli.run_cli(parser, args, MockMultiCatalogOutputAdapter, cfg=self.config)
-                for idx in range(3):
-                    cat = Catalog.from_file(os.path.join(self.workdir, f'catalog{idx}.json'))
-                    cat_root = cat.get_single_link('root')
-                    self.assertEqual(cat_root.get_href(), f'./catalog{idx}.json')
-                    item_hrefs = [l.get_href() for l in cat.get_links('item')]
-                    self.assertTrue(f'./item-1-from-catalog-{cat.id}/item-1-from-catalog-{cat.id}.json' in item_hrefs)
-                    self.assertTrue(f'./item-2-from-catalog-{cat.id}/item-2-from-catalog-{cat.id}.json' in item_hrefs)
-                    item = Item.from_file(os.path.join(self.workdir, f'./item-1-from-catalog-{cat.id}/item-1-from-catalog-{cat.id}.json'))
-                    item_root_href = item.get_single_link('root').get_href()
-                    item_parent_href = item.get_single_link('parent').get_href()
-                    self.assertTrue(item_parent_href == item_root_href)
-                    self.assertEqual(item_root_href, f'../catalog{idx}.json')
-                    self.assertEqual(item_parent_href, f'../catalog{idx}.json')
-                with open(os.path.join(self.workdir, 'batch-count.txt')) as file:
-                    self.assertEqual(file.read(), '3')
-                with open(os.path.join(self.workdir, 'batch-catalogs.json')) as file:
-                    self.assertEqual(json.loads(file.read()),
-                        ["catalog0.json",
-                         "catalog1.json",
-                         "catalog2.json"])
+        with cli_parser(
+                '--harmony-action', 'invoke',
+                '--harmony-input', '{"test": "input"}',
+                '--harmony-sources', 'example/source/catalog.json',
+                '--harmony-metadata-dir', self.workdir) as parser:
+            args = parser.parse_args()
+            cli.run_cli(parser, args, MockMultiCatalogOutputAdapter, cfg=self.config)
+            for idx in range(3):
+                cat = Catalog.from_file(os.path.join(self.workdir, f'catalog{idx}.json'))
+                cat_root = cat.get_single_link('root')
+                self.assertEqual(cat_root.get_href(), f'./catalog{idx}.json')
+                item_hrefs = [l.get_href() for l in cat.get_links('item')]
+                self.assertTrue(f'./item-1-from-catalog-{cat.id}/item-1-from-catalog-{cat.id}.json' in item_hrefs)
+                self.assertTrue(f'./item-2-from-catalog-{cat.id}/item-2-from-catalog-{cat.id}.json' in item_hrefs)
+                item = Item.from_file(os.path.join(
+                    self.workdir, f'./item-1-from-catalog-{cat.id}/item-1-from-catalog-{cat.id}.json'))
+                item_root_href = item.get_single_link('root').get_href()
+                item_parent_href = item.get_single_link('parent').get_href()
+                self.assertTrue(item_parent_href == item_root_href)
+                self.assertEqual(item_root_href, f'../catalog{idx}.json')
+                self.assertEqual(item_parent_href, f'../catalog{idx}.json')
+            with open(os.path.join(self.workdir, 'batch-count.txt')) as file:
+                self.assertEqual(file.read(), '3')
+            with open(os.path.join(self.workdir, 'batch-catalogs.json')) as file:
+                self.assertEqual(json.loads(file.read()),
+                                 ["catalog0.json",
+                                  "catalog1.json",
+                                  "catalog2.json"])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1983

## Description
Here is a description of the full NoData/EmptyResult error handling workflow from the beginning to the end:

1) Service implementer throws NoDataException in service code when NoData/EmptyResult error is encountered.
2) harmony-service-lib-py defines the new NoDataException and catches it when it is thrown from the service invocation. It saves the NoDataException as a warning in the error.json file for the work item service invocation.
3) Harmony service-runner reads the error.json file when detecting the service call failed, then construct the workitem with the warning info and call the backend work item update endpoint to update the work item.
4) Harmony backend saves the workitem in database with a 'warning' status and save the warning info into `job_errors` table which has new columns `level` and `category` added.
5) Harmony workflow-ui will be updated to display the warning status/category on work items page
6) Harmony job status response will be updated to include a new `warnings` field with all the warning work items.
7) Hamrony miscellaneous updates to deal with the addition of 'warning' status of work item and `job_errors` db schema changes.
8) Optional: Update harmony to not retry on NoData warning work items

This PR is step #2 in the chain of the workflow. I tested with harmony-service-example, when it throws NoDataException, the work item processing will fail with the correct error message in the exception (see below) and the error.json file has the following content:

`{"error": "No data found to process", "category": "NoData", "level": "Warning"}`
![Screenshot 2025-01-24 at 11 33 56 AM](https://github.com/user-attachments/assets/782e291a-01dd-4b23-8373-e6cc8320a3fd)


## Local Test Steps
Modify harmony-service-example `process_item` function to throw NoDataException. Build harmony-service-example with this branch of harmony-service-lib-py. 
Submit a service example request. e.g. http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng

Verify the request fails with the proper no data error and the error.json file created in s3 matches the description section above.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)