### PR TITLE
HARMONY-1972: Prevent exception when trying to read a response from an HTTP file download.

### DIFF
--- a/harmony_service_lib/http.py
+++ b/harmony_service_lib/http.py
@@ -369,7 +369,7 @@ def download(config, url: str, access_token: str, data, destination_file,
             config, url, access_token, data, config.max_download_retries, logger, user_agent, stream=stream
         )
 
-    if response.ok:
+    if response is not None and response.ok:
         if not stream:
             destination_file.write(response.content)
             file_size = sys.getsizeof(response.content)


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1972

## Description
Improve the error message when trying to read a response from an HTTP file download when the connection to the download site is dropped.

## Local Test Steps
Note that I do not have a reliable way to reproduce the issue from the ticket. This will at a minimum ensure that we don't return the message to the end user: "AttributeError: 'NoneType' object has no attribute 'ok'".

Build the harmony service example using this branch and submit a request to sanity check downloads still work as expected.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)