### PR TITLE
HARMONY-1965: Add pixelSubset to data operation schema 0.21.0

### DIFF
--- a/example/example_message.json
+++ b/example/example_message.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "../../harmony/app/schemas/data-operation/0.20.0/data-operation-v0.20.0.json",
-  "version": "0.20.0",
+  "$schema": "../../harmony/app/schemas/data-operation/0.21.0/data-operation-v0.21.0.json",
+  "version": "0.21.0",
   "callback": "http://localhost/some-path",
   "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
   "user": "jdoe",
@@ -70,6 +70,7 @@
     "lat",
     "lon"
   ],
+  "pixelSubset": false,
   "extraArgs": {
     "cut": false
   }

--- a/harmony_service_lib/message.py
+++ b/harmony_service_lib/message.py
@@ -619,6 +619,8 @@ class Message(JsonObject):
         The averaging method to use
     extendDimensions: list
         A list of dimensions to extend.
+    pixelSubset : bool
+        True if pixel subset should be performed by the service.
     extraArgs: object
         A map of key (string type) and value (any type) pairs indicating the extra arguments
         that should be passed to the worker command
@@ -659,6 +661,7 @@ class Message(JsonObject):
                 'concatenate',
                 'average',
                 'extendDimensions',
+                'pixelSubset',
                 'extraArgs'
             ],
             list_properties={'sources': Source}

--- a/tests/example_messages.py
+++ b/tests/example_messages.py
@@ -1,7 +1,7 @@
 minimal_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
-        "version": "0.20.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.21.0/data-operation-v0.21.0.json",
+        "version": "0.21.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -19,8 +19,8 @@ minimal_message = """
 
 minimal_source_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
-        "version": "0.20.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.21.0/data-operation-v0.21.0.json",
+        "version": "0.21.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -46,8 +46,8 @@ minimal_source_message = """
 
 full_message = """
     {
-        "$schema": "../../harmony/app/schemas/data-operation/0.19.0/data-operation-v0.19.0.json",
-        "version": "0.20.0",
+        "$schema": "../../harmony/app/schemas/data-operation/0.21.0/data-operation-v0.21.0.json",
+        "version": "0.21.0",
         "callback": "http://localhost/some-path",
         "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
         "user": "jdoe",
@@ -182,6 +182,7 @@ full_message = """
         "concatenate": true,
         "average": "time",
         "extendDimensions": ["lat", "lon"],
+        "pixelSubset": true,
         "extraArgs": {
             "cut": false,
             "intParam": 100,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -13,7 +13,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_full_message_it_parses_it_into_objects(self):
         message = Message(full_message)
 
-        self.assertEqual(message.version, '0.20.0')
+        self.assertEqual(message.version, '0.21.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -80,13 +80,14 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message.subset.dimensions[1].min, None)
         self.assertEqual(message.subset.dimensions[1].max, 10)
         self.assertEqual(message.extendDimensions, ["lat", "lon"])
+        self.assertEqual(message.pixelSubset, True)
         self.assertEqual(message.extraArgs['cut'], False)
 
 
     def test_when_provided_a_minimal_message_it_parses_it_into_objects(self):
         message = Message(minimal_message)
 
-        self.assertEqual(message.version, '0.20.0')
+        self.assertEqual(message.version, '0.21.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.stagingLocation, 's3://example-bucket/public/some-org/some-service/some-uuid/')
         self.assertEqual(message.user, 'jdoe')
@@ -106,7 +107,7 @@ class TestMessage(unittest.TestCase):
     def test_when_provided_a_message_with_minimal_source_it_parses_it_into_objects(self):
         message = Message(minimal_source_message)
 
-        self.assertEqual(message.version, '0.20.0')
+        self.assertEqual(message.version, '0.21.0')
         self.assertEqual(message.callback, 'http://localhost/some-path')
         self.assertEqual(message.user, 'jdoe')
         self.assertEqual(message.accessToken, 'ABCD1234567890')


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1965

## Description
Add pixelSubset to data operation schema 0.21.0

## Local Test Steps
Follow instructions in Harmony PR: https://github.com/nasa/harmony/pull/703 to test.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)