### PR TITLE
TRT-42: Add function to create history metadata attribute.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ autopep8 ~= 1.5
 debugpy ~= 1.2
 Faker ~= 8.1.3
 flake8 >= 6.1.0
+freezegun ~= 1.5.1
 ipython ~= 8.10.0
 jedi ~= 0.17.2
 packaging ~= 24.1

--- a/harmony_service_lib/provenance.py
+++ b/harmony_service_lib/provenance.py
@@ -16,7 +16,7 @@ def get_updated_history_metadata(
     service_version: str,
     existing_history: str | None = None,
 ) -> str:
-    """Create updated the history global attribute.
+    """Create updated history global attribute.
 
     This function primarily ensures the correct formatting of the history
     string, and is agnostic to the format of the input file.

--- a/harmony_service_lib/provenance.py
+++ b/harmony_service_lib/provenance.py
@@ -1,0 +1,27 @@
+"""Utility functionality for generating provenance metadata."""
+
+from datetime import datetime, UTC
+
+
+def get_updated_history_metadata(
+    service_name: str,
+    service_version: str,
+    existing_history: str | None = None,
+) -> str:
+    """Create updated the history global attribute.
+
+    This function primarily ensures the correct formatting of the history
+    string, and is agnostic to the format of the input file.
+
+    """
+    new_history_line = ' '.join(
+        [
+            datetime.now(UTC).isoformat(),
+            service_name,
+            service_version,
+        ]
+    )
+
+    return '\n'.join(
+        filter(None, [existing_history, new_history_line])
+    )

--- a/harmony_service_lib/provenance.py
+++ b/harmony_service_lib/provenance.py
@@ -1,6 +1,14 @@
 """Utility functionality for generating provenance metadata."""
+from __future__ import annotations
 
-from datetime import datetime, UTC
+from datetime import datetime
+
+try:
+    # datetime.UTC added in Python 3.11
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+    UTC = timezone.utc
 
 
 def get_updated_history_metadata(

--- a/harmony_service_lib/provenance.py
+++ b/harmony_service_lib/provenance.py
@@ -21,6 +21,23 @@ def get_updated_history_metadata(
     This function primarily ensures the correct formatting of the history
     string, and is agnostic to the format of the input file.
 
+    Parameters
+    ----------
+        service_name : str
+            The name of the service processing a file.
+        service_version : str
+            The semantic version number of the service processing a file.
+        existing_history : str, optional
+            Any existing content from a "history" or "History" metadata
+            attribute, to which new information should be appended.
+
+    Returns
+    -------
+        str
+            Updated value for history metadata attribute. If an existing
+            history value was supplied, the new information is appended to that
+            value, and delimited by a newline.
+
     """
     new_history_line = ' '.join(
         [

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from freezegun import freeze_time
+
+from harmony_service_lib.provenance import get_updated_history_metadata
+
+
+@freeze_time('2001-02-03T04:05:06')
+class TestProvenance(TestCase):
+    """Test class for functions in harmony_service_lib.provenance."""
+
+    def test_get_updated_history_metadata_existing_history(self):
+        """A new line should be appended to the existing history metadata."""
+        self.assertEqual(
+            get_updated_history_metadata(
+                'Amazing Service',
+                '1.2.3',
+                '1999-12-11T10:09:08 File created',
+            ),
+            '1999-12-11T10:09:08 File created\n2001-02-03T04:05:06+00:00 Amazing Service 1.2.3',
+        )
+
+    def test_get_updated_history_metadata_no_existing_history(self):
+        """The output should only be the newly created history metadata."""
+        self.assertEqual(
+            get_updated_history_metadata(
+                'Amazing Service',
+                '1.2.3',
+            ),
+            '2001-02-03T04:05:06+00:00 Amazing Service 1.2.3',
+        )


### PR DESCRIPTION
## Jira Issue ID

TRT-42 (centralising some functionality to support the intent of that feature)

## Description

This PR adds a fairly simplistic function to create a correctly formatted `history` attribute string, with a view to centralising that functionality for Harmony services.

The function tries to stay agnostic to both the file format where the metadata attribute either comes from or is to be written, and to the packages used to by specific services to interact with those file formats (e.g., `xarray` versus `netCDF4` versus `h5py`, etc). That severely limits the scope of the function and is what makes it very lightweight.

Right now the `provenance.py` module has only one function in it, but in the future `history_json` creation could/should also be added here. Having this module at least gives us a location to start placing such functionality.

## Local Test Steps

* Pull this branch locally.
* Run the tests (`make install && make test`) - the tests should all pass.
* Import the function and run it locally:

```
from harmony_service_lib.provenance import get_updated_history_metadata

history_metadata = get_updated_history_metadata(
    '<service name>',
    '<service version>',
    '<pre-existing value of history metadata attribute>',
)
```

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* [x] Tests added/updated (if needed) and passing
* ~~Documentation updated (if needed)~~