### PR TITLE
TRT-572: Update grid self-consistency validation.

### DIFF
--- a/harmony_service_lib/message_utility.py
+++ b/harmony_service_lib/message_utility.py
@@ -28,6 +28,10 @@ def has_self_consistent_grid(message: Message, valid_if_no_grid: bool = False) -
     scaleExtent, scaleSize and specified dimension length, height or width, are
     consistent.
 
+    If no grid parameters are provided, or only one of the three are defined,
+    then the function will return the value of `valid_if_no_grid`, as there is
+    insufficient information to determine if the grid is self-consistent.
+
     Parameters
     ----------
         message : harmony_service_lib.message.Message
@@ -43,7 +47,8 @@ def has_self_consistent_grid(message: Message, valid_if_no_grid: bool = False) -
     -------
         bool
             Value indicating if the Harmony message parameters met the criteria
-            for grid self-consistency. If there are no grid parameters, then
+            for grid self-consistency. If there are no grid parameters, or only
+            one of scaleExtents, scaleSize or height/width are provided, then
             the return value is determined by `valid_if_no_grid`, which
             defaults to `False`.
 

--- a/harmony_service_lib/message_utility.py
+++ b/harmony_service_lib/message_utility.py
@@ -9,23 +9,43 @@ from typing import Any, List
 from harmony_service_lib.message import Message
 
 
-def has_self_consistent_grid(message: Message) -> bool:
-    """ Check the input Harmony message provides enough information to fully
-        define the target grid. At minimum the message should contain the scale
-        extents (minimum and maximum values) in the horizontal spatial
-        dimensions and one of the following two pieces of information:
+def has_self_consistent_grid(message: Message, valid_if_no_grid: bool = False) -> bool:
+    """Check the input Harmony message defines a self-consistent grid.
+
+    At minimum a self-consistent grid should define the scale extents
+    (minimum and maximum values) in the horizontal spatial dimensions and
+    one of the following two pieces of information:
 
         * Message.format.scaleSize - defining the x and y pixel size.
         * Message.format.height and Message.format.width - the number of pixels
           in the x and y dimension.
 
-        If all three pieces of information are supplied, they will be checked
-        to ensure they are consistent with one another.
+    If all three pieces of information are supplied, they will be checked to
+    ensure they are consistent with one another.
 
-        If scaleExtent and scaleSize are defined, along with only one of
-        height or width, the grid will be considered consistent if the three
-        values for scaleExtent, scaleSize and specified dimension length,
-        height or width, are consistent.
+    If scaleExtent and scaleSize are defined, along with only one of height or
+    width, the grid will be considered consistent if the three values for
+    scaleExtent, scaleSize and specified dimension length, height or width, are
+    consistent.
+
+    Parameters
+    ----------
+        message : harmony_service_lib.message.Message
+            The Harmony message object provided to a service for a request.
+        valid_if_no_grid : bool, optional
+            Optional parameter stating whether the validation check should pass
+            if the message does not contain any grid parameters. Applicable to
+            instances when only a target projection is specified in a request,
+            with the expectation that the target grid will cover the horizontal
+            spatial area of the input granule. Default value is `False`.
+
+    Returns
+    -------
+        bool
+            Value indicating if the Harmony message parameters met the criteria
+            for grid self-consistency. If there are no grid parameters, then
+            the return value is determined by `valid_if_no_grid`, which
+            defaults to `False`.
 
     """
     if (
@@ -50,7 +70,7 @@ def has_self_consistent_grid(message: Message) -> bool:
     ):
         consistent_grid = True
     else:
-        consistent_grid = False
+        consistent_grid = valid_if_no_grid
 
     return consistent_grid
 

--- a/tests/test_message_utilities.py
+++ b/tests/test_message_utilities.py
@@ -118,7 +118,6 @@ class TestMessageUtility(TestCase):
             })
             self.assertFalse(has_self_consistent_grid(test_message, True))
 
-
     def test_self_has_self_consistent_grid_missing_height_or_width(self):
         """ Ensure that the function correctly determines if the supplied
             Harmony message defines a valid target grid. These test cases check
@@ -127,6 +126,10 @@ class TestMessageUtility(TestCase):
             If there is sufficient other grid information, and the one listed
             dimension with all three pieces of information is self consistent,
             then the message passes validation.
+
+            If there are grids with insufficient information, but
+            `valid_if_no_grid=True`, then the validation should pass for
+            under-defined grids.
 
         """
         valid_scale_extents = {'x': {'min': -180, 'max': 180},
@@ -196,6 +199,41 @@ class TestMessageUtility(TestCase):
             })
             self.assertTrue(has_self_consistent_grid(test_message))
 
+        with self.subTest('Only height and scaleExtent, uses valid_if_no_grid=True'):
+            test_message = Message({
+                'format': {'height': valid_height,
+                           'scaleExtent': valid_scale_extents}
+            })
+            self.assertTrue(
+                has_self_consistent_grid(test_message, valid_if_no_grid=True)
+            )
+
+        with self.subTest('Only width and scaleExtent, uses valid_if_no_grid=True'):
+            test_message = Message({
+                'format': {'scaleExtent': valid_scale_extents,
+                           'width': valid_width}
+            })
+            self.assertTrue(
+                has_self_consistent_grid(test_message, valid_if_no_grid=True)
+            )
+
+        with self.subTest('Only height and scaleSize, uses valid_if_no_grid=True'):
+            test_message = Message({
+                'format': {'height': valid_height,
+                           'scaleSize': valid_scale_sizes}
+            })
+            self.assertTrue(
+                has_self_consistent_grid(test_message, valid_if_no_grid=True)
+            )
+
+        with self.subTest('Only width and scaleSize, usses valid_if_no_grid=True'):
+            test_message = Message({
+                'format': {'scaleSize': valid_scale_sizes,
+                           'width': valid_width}
+            })
+            self.assertTrue(
+                has_self_consistent_grid(test_message, valid_if_no_grid=True)
+            )
 
     def test_message_has_crs(self):
         message = Message({'format': {'crs': 'EPSG:4326'}})

--- a/tests/test_message_utilities.py
+++ b/tests/test_message_utilities.py
@@ -41,6 +41,10 @@ class TestMessageUtility(TestCase):
             test_message = Message({})
             self.assertFalse(has_self_consistent_grid(test_message))
 
+        with self.subTest('No grid params, valid_if_no_grid = True returns True'):
+            test_message = Message({})
+            self.assertTrue(has_self_consistent_grid(test_message, True))
+
         with self.subTest('All grid parameters = None returns False'):
             test_message = Message({'format': {}})
             self.assertFalse(has_self_consistent_grid(test_message))
@@ -104,6 +108,16 @@ class TestMessageUtility(TestCase):
                            'width': valid_width - 150}
             })
             self.assertFalse(has_self_consistent_grid(test_message))
+
+        with self.subTest('Inconsistent grid, valid_if_no_grid=True, returns False'):
+            test_message = Message({
+                'format': {'height': valid_height + 150,
+                           'scaleExtent': valid_scale_extents,
+                           'scaleSize': valid_scale_sizes,
+                           'width': valid_width - 150}
+            })
+            self.assertFalse(has_self_consistent_grid(test_message, True))
+
 
     def test_self_has_self_consistent_grid_missing_height_or_width(self):
         """ Ensure that the function correctly determines if the supplied


### PR DESCRIPTION
## Jira Issue ID

TRT-572 (small supporting work)

## Description

This PR updates the `has_self_consistent_grid` function to add an optional argument stating whether the message is valid if there are no grid parameters defined. This value is returned in the final case, when there are none of:

* `format.scaleExtent`
* `format.scaleSize`
* `format.height` _and_ `format.width`

The default value of this new argument is `False`, which preserves prior behaviour.

This change supports use-cases for the Harmony Regridding Service (particularly via EDSC), when an end-user may specify a projection, but no grid parameters. Indeed, EDSC does not allow users to provide grid parameters at this point.

## Local Test Steps

* Pull this branch.
* Define an empty Harmony message.
  * Call this function using that empty message, without defining `valid_if_no_grid` - should return `False`.
  * Call this function using that empty message, setting `valid_if_no_grid=False` - should return `False`.
  * Call this function using that empty message, setting `valid_if_no_grid=True` - should return `True`.
* Create a message with inconsistent grid parameters (so `scaleSize.x != scaleExtent.x / width` or same for `y`).
  * Call this function using that empty message, without defining `valid_if_no_grid` - should return `False`.
  * Call this function using that empty message, setting `valid_if_no_grid=False` - should return `False`.
  * Call this function using that empty message, setting `valid_if_no_grid=True` - should return `False`. (Because there is a grid, and it is not self-consistent)

## PR Acceptance Checklist
* ~~Acceptance criteria met~~ this helps, but is only a _very_ small piece
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed) - I updated the documentation string accordingly.