### PR TITLE
HARMONY-2159: Add NoRetryException to support services returning non-retriable errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ harmony_service_lib provides the following custom exceptions:
 - **CanceledException**: Raised when a Harmony request is canceled.
 - **ForbiddenException**: Raised when access to the requested data is denied (e.g., download failure due to permission issues).
 - **ServerException**: Raised for generic 500 internal server errors (e.g., a download failure due to a server issue).
+- **NoRetryException**: Raised when a fatal error occurs that is specific to the request and cannot be resolved by retrying.
 - **NoDataException**: Raised when the service finds no data to process (e.g., no data found by the service in the subset region). This is classified as a `Warning` exception.
 
 ### Customized Service Exceptions

--- a/harmony_service_lib/exceptions.py
+++ b/harmony_service_lib/exceptions.py
@@ -38,6 +38,14 @@ class ServerException(HarmonyException):
         super().__init__(message, 'Server')
 
 
+class NoRetryException(HarmonyException):
+    """Class for throwing an exception indicating the error is a fatal error that is specific to a request
+    and should not be retried by Harmony."""
+
+    def __init__(self, message=None):
+        super().__init__(message, 'NoRetry')
+
+
 class NoDataException(HarmonyException):
     """Class for throwing an exception indicating service found no data to process """
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2159

## Description
Add NoRetryException to support services returning non-retriable errors.

## Local Test Steps
make install

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)