### PR TITLE
DAS-2373: Call Exception(message) for Harmony exceptions.

### DIFF
--- a/harmony_service_lib/exceptions.py
+++ b/harmony_service_lib/exceptions.py
@@ -12,6 +12,7 @@ class HarmonyException(Exception):
     """
 
     def __init__(self, message, category='Service', level='Error'):
+        super().__init__(message)
         self.message = message
         self.category = category
         self.level = level

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,20 @@
+import pytest
+from harmony_service_lib.exceptions import HarmonyException
+
+def test_harmony_exception_str_representation():
+    """Test that HarmonyException properly calls parent __init__ so str() works correctly"""
+    message = "Test error message"
+
+    with pytest.raises(HarmonyException, match='.*Test error message$'):
+        raise HarmonyException(message)
+
+
+def test_harmony_exception_with_custom_exception():
+    """Test that CustomExceptions with params expecte properly."""
+    class CustomError(HarmonyException):
+        def __init__(self, params: set[str]):
+            message = f'Params are bad: {params}'
+            super().__init__(message)
+
+    with pytest.raises(CustomError, match=r'Params are bad\:.*'):
+        raise CustomError({'bad', 'param'})


### PR DESCRIPTION
## Jira Issue ID

ostensibly DAS-2373, but I just found my exceptions weren't working as expected in my tests so here's a PR to fix that.


~I'm not 100% sure this is generally acceptable behavior.~. I'm pretty sure since HarmonyException defines it's own `__init__` function, we should call the parent's constructor directly.

## Description

Harmony's base custom extension calls the parent constructor with a message.


## Local Test Steps

Pull this branch, run the tests 
```
❯ make install && make lint && make test
```

You can revert the change in the source to see the second test fail if you're feeling up to it.

## PR Acceptance Checklist
* [ ] ~Acceptance criteria met~
* [X] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~