### PR TITLE
HARMONY-2346: Update urllib3 dependency to prevent vulnerability.

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: '0'
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/harmony_service_lib/message.py
+++ b/harmony_service_lib/message.py
@@ -414,7 +414,7 @@ class Format(JsonObject):
     crs: string
         A proj4 string or EPSG code corresponding to the desired output projection
     srs: message.SRS
-        The output CRS information; overlappting information with 'crs'
+        The output CRS information; overlapping information with 'crs'
     isTransparent: boolean
         A boolean corresponding to whether or not nodata values should be set to transparent
         in the output if the file format allows it

--- a/harmony_service_lib/provenance.py
+++ b/harmony_service_lib/provenance.py
@@ -1,5 +1,4 @@
 """Utility functionality for generating provenance metadata."""
-from __future__ import annotations
 
 from datetime import datetime
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ deprecation ~= 2.1.0
 pynacl ~= 1.4
 pystac >= 1.0.0
 python-json-logger ~= 2.0.1
+
+# Pinned for CVE-2026-44432 and CVE-2026-44431
+urllib3 >= 2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ deprecation ~= 2.1.0
 pynacl ~= 1.4
 pystac >= 1.0.0
 python-json-logger ~= 2.0.1
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@ deprecation ~= 2.1.0
 pynacl ~= 1.4
 pystac >= 1.0.0
 python-json-logger ~= 2.0.1
-requests ~= 2.31
-urllib3 ~= 2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,3 @@ deprecation ~= 2.1.0
 pynacl ~= 1.4
 pystac >= 1.0.0
 python-json-logger ~= 2.0.1
-
-# Pinned for CVE-2026-44432 and CVE-2026-44431
-urllib3 >= 2.7


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2346](https://bugs.earthdata.nasa.gov/browse/HARMONY-2346)

## Description

Removes urllib3 pin to prevent vulnerability in versions < 2.7

see CVE-2026-44432 and CVE-2026-44431

When released it will close #75 

## Local Test Steps

1. See that the tests work in GitHub actions.



## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~